### PR TITLE
Add support to N64.ino for some cartridges with alternative FlashRAM ICs

### DIFF
--- a/Cart_Reader/N64.ino
+++ b/Cart_Reader/N64.ino
@@ -2047,6 +2047,15 @@ void getFramType() {
     println_Msg(F("Type: MN63F81MPN"));
     display_Update();
   }
+  // 29L1100KC-15B0 compat MX29L1101
+  else if ((sdBuffer[7] == 0x8e ) || (sdBuffer[7] == 0x84 ))
+  {
+    flashramType = 1;
+    MN63F81MPN = false;
+    println_Msg(F("Type: 29L1100KC-15B0"));
+    println_Msg(F("(compat. MX29L1101)"));
+    display_Update();
+  }
   // Type unknown
   else {
     for (byte c = 0; c < 8; c++) {


### PR DESCRIPTION
Some cartridges might have differing versions depending on the region they were released to.  In most cases, the IC identifies as something else not presently covered by the current code, but they are ABI compatible with the existent FlashRAM supported types.

This will add support for 29L1100KC-15B0 compatible ICs like the MX29L1101.