### PR TITLE
small change that allows using Visual Micro instead of the Arduino IDE

### DIFF
--- a/Cart_Reader/Cart_Reader.ino
+++ b/Cart_Reader/Cart_Reader.ino
@@ -38,6 +38,9 @@
    rama - Snes speedup
 
 **********************************************************************************/
+
+#include <SdFat.h>
+
 char ver[5] = "3.3";
 
 /******************************************
@@ -117,7 +120,6 @@ typedef enum COLOR_T {
 } color_t;
 
 // SD Card (Pin 50 = MISO, Pin 51 = MOSI, Pin 52 = SCK, Pin 53 = SS)
-#include <SdFat.h>
 #define chipSelectPin 53
 SdFat sd;
 SdFile myFile;


### PR DESCRIPTION
Visual Micro is an extension for Visual Studio, a much more capable IDE than regular Arduino.

As part of the build process it combines all .ino files into one large file.
When building the file, some #includes need to be the first code it sees, else the step fails.

This is the minimum amount of change that makes it work.
It'd be great to have it ;p 