### PR TITLE
arduino_reset

### DIFF
--- a/Cart_Reader/Cart_Reader.ino
+++ b/Cart_Reader/Cart_Reader.ino
@@ -85,6 +85,7 @@ boolean n64crc = 1;
 #include <SPI.h>
 #include <Wire.h>
 #include <avr/pgmspace.h>
+#include <avr/wdt.h>
 
 // AVR Eeprom
 #include <EEPROM.h>
@@ -374,12 +375,12 @@ void aboutScreen() {
 
       // if the cart readers input button is pressed shortly
       if (b == 1) {
-        asm volatile ("  jmp 0");
+        resetArduino();
       }
 
       // if the cart readers input button is pressed long
       if (b == 3) {
-        asm volatile ("  jmp 0");
+        resetArduino();
       }
 
       // if the button is pressed super long
@@ -390,16 +391,21 @@ void aboutScreen() {
         delay(2000);
         foldern = 0;
         EEPROM_writeAnything(10, foldern);
-        asm volatile ("  jmp 0");
+        resetArduino();
       }
     }
     if (enable_Serial) {
       wait_serial();
-      asm volatile ("  jmp 0");
+      resetArduino();
     }
     rgb.setColor(random(0, 255), random(0, 255), random(0, 255));
     delay(random(50, 100));
   }
+}
+
+void resetArduino() {
+  wdt_enable(WDTO_15MS);
+  while (1);
 }
 
 void mainMenu() {
@@ -577,7 +583,7 @@ void print_Error(const __FlashStringHelper *errorMessage, boolean forceReset) {
       display_Update();
       wait();
       if (ignoreError == 0) {
-        asm volatile ("  jmp 0");
+        resetArduino();
       }
       else {
         ignoreError = 0;
@@ -1377,7 +1383,7 @@ void loop() {
     println_Msg(F("Press Button..."));
     display_Update();
     wait();
-    asm volatile ("  jmp 0");
+    resetArduino();
   }
 }
 

--- a/Cart_Reader/FLASH.ino
+++ b/Cart_Reader/FLASH.ino
@@ -220,7 +220,7 @@ void flashromMenu8() {
         resetFlash29F032();
       else
         resetFlash29F1610();
-      asm volatile ("  jmp 0");
+      resetArduino();
       break;
   }
   if (time != 0) {
@@ -318,7 +318,7 @@ void flashromMenu16() {
       display_Clear();
       display_Update();
       resetFlash16();
-      asm volatile ("  jmp 0");
+      resetArduino();
       break;
   }
   if (time != 0) {
@@ -385,7 +385,7 @@ void epromMenu() {
       time = 0;
       display_Clear();
       display_Update();
-      asm volatile ("  jmp 0");
+      resetArduino();
       break;
   }
   if (time != 0) {

--- a/Cart_Reader/GB.ino
+++ b/Cart_Reader/GB.ino
@@ -125,7 +125,7 @@ void gbMenu() {
       writeFlash_GB(3);
       // Reset
       wait();
-      asm volatile ("  jmp 0");
+      resetArduino();
       break;
 
     case 4:
@@ -135,11 +135,11 @@ void gbMenu() {
       writeFlash_GB(5);
       // Reset
       wait();
-      asm volatile ("  jmp 0");
+      resetArduino();
       break;
 
     case 5:
-      asm volatile ("  jmp 0");
+      resetArduino();
       break;
   }
   println_Msg(F(""));

--- a/Cart_Reader/GBA.ino
+++ b/Cart_Reader/GBA.ino
@@ -473,11 +473,11 @@ void gbaMenu() {
       println_Msg(F("Press Button..."));
       display_Update();
       wait();
-      asm volatile ("  jmp 0");
+      resetArduino();
       break;
 
     case 5:
-      asm volatile ("  jmp 0");
+      resetArduino();
       break;
   }
 

--- a/Cart_Reader/MD.ino
+++ b/Cart_Reader/MD.ino
@@ -226,7 +226,7 @@ void mdMenu() {
 
     case 6:
       // Reset
-      asm volatile ("  jmp 0");
+      resetArduino();
       break;
   }
   println_Msg(F(""));

--- a/Cart_Reader/N64.ino
+++ b/Cart_Reader/N64.ino
@@ -183,7 +183,7 @@ void n64ControllerMenu() {
       break;
 
     case 3:
-      asm volatile ("  jmp 0");
+      resetArduino();
       break;
   }
 }
@@ -341,7 +341,7 @@ void n64CartMenu() {
       break;
 
     case 4:
-      asm volatile ("  jmp 0");
+      resetArduino();
       break;
   }
 }
@@ -2192,7 +2192,7 @@ calcn64crc:
 
         case 3:
           // Reset
-          asm volatile ("  jmp 0");
+          resetArduino();
           break;
       }
     }

--- a/Cart_Reader/NP.ino
+++ b/Cart_Reader/NP.ino
@@ -78,7 +78,7 @@ void sfmMenu() {
       break;
     // Reset
     case 2:
-      asm volatile ("  jmp 0");
+      resetArduino();
       break;
   }
 }
@@ -205,7 +205,7 @@ void sfmGameOptions() {
 
     // Reset
     case 4:
-      asm volatile ("  jmp 0");
+      resetArduino();
       break;
   }
   if (gameSubMenu != 3) {

--- a/Cart_Reader/PCE.ino
+++ b/Cart_Reader/PCE.ino
@@ -863,7 +863,7 @@ void pceMenu() {
         write_tennokoe_bank_PCE();
         break;
       case 3:
-        asm volatile ("  jmp 0");
+        resetArduino();
         break;
     }
   }
@@ -884,7 +884,7 @@ void pceMenu() {
         break;
   
       case 1:
-        asm volatile ("  jmp 0");
+        resetArduino();
         break;
     }
   }

--- a/Cart_Reader/SNES.ino
+++ b/Cart_Reader/SNES.ino
@@ -212,11 +212,11 @@ void snesMenu() {
       print_Msg("Resetting...");
       display_Update();
       delay(3000);  // wait 3 secs to switch to next game
-      asm volatile ("  jmp 0");
+      resetArduino();
       break;
 
     case 5:
-      asm volatile ("  jmp 0");
+      resetArduino();
       break;
   }
   println_Msg(F(""));
@@ -262,7 +262,7 @@ void confMenu() {
 
     case 4:
       // Reset
-      asm volatile ("  jmp 0");
+      resetArduino();
       break;
   }
 }
@@ -1675,7 +1675,7 @@ unsigned long verifySRAM() {
       print_Msg("Resetting...");
       display_Update();
       delay(3000);  // wait 3 secs
-      asm volatile ("  jmp 0");
+      resetArduino();
     }
     // Close the file:
     myFile.close();

--- a/Cart_Reader/SV.ino
+++ b/Cart_Reader/SV.ino
@@ -59,7 +59,7 @@ void svMenu() {
 
     // Reset
     case 2:
-      asm volatile ("  jmp 0");
+      resetArduino();
       break;
   }
 }


### PR DESCRIPTION
replace the assembler jmp 0 reset method with resetArduino() that uses the watchdog timer to reset the device. This is the preferred method, as it initializes the device more correctly.