### PR TITLE
strings_to_flash

### DIFF
--- a/Cart_Reader/Cart_Reader.ino
+++ b/Cart_Reader/Cart_Reader.ino
@@ -413,7 +413,7 @@ void mainMenu() {
   unsigned char modeMenu;
   // Copy menuOptions out of progmem
   convertPgm(modeOptions, 7);
-  modeMenu = question_box("Cartridge Reader", menuOptions, 7, 0);
+  modeMenu = question_box(F("Cartridge Reader"), menuOptions, 7, 0);
 
   // wait for user choice to come back from the question box menu
   switch (modeMenu)
@@ -692,7 +692,7 @@ void display_Clear() {
   }
 }
 
-unsigned char question_box(const char* question, char answers[7][20], int num_answers, int default_choice) {
+unsigned char question_box(const __FlashStringHelper* question, char answers[7][20], int num_answers, int default_choice) {
   if (enable_OLED) {
     return questionBox_OLED(question, answers, num_answers, default_choice);
   }
@@ -740,7 +740,7 @@ void wait_serial() {
     }*/
 }
 
-byte questionBox_Serial(const char* question, char answers[7][20], int num_answers, int default_choice) {
+byte questionBox_Serial(const __FlashStringHelper* question, char answers[7][20], int num_answers, int default_choice) {
   // Print menu to serial monitor
   //Serial.println(question);
   for (byte i = 0; i < num_answers; i++) {
@@ -787,9 +787,9 @@ byte questionBox_Serial(const char* question, char answers[7][20], int num_answe
       foldern = foldern + 1;
       EEPROM_writeAnything(10, foldern);
 
-      print_Msg("Imported ");
+      print_Msg(F("Imported "));
       print_Msg(fileSize);
-      print_Msg(" bytes to file ");
+      print_Msg(F(" bytes to file "));
       println_Msg(fileName);
       return 7;
     }
@@ -1018,7 +1018,7 @@ void wait_btn() {
 }
 
 // Display a question box with selectable answers. Make sure default choice is in (0, num_answers]
-unsigned char questionBox_OLED(const char* question, char answers[7][20], int num_answers, int default_choice) {
+unsigned char questionBox_OLED(const __FlashStringHelper* question, char answers[7][20], int num_answers, int default_choice) {
 
   //clear the screen
   display.clearDisplay();
@@ -1145,7 +1145,7 @@ unsigned char questionBox_OLED(const char* question, char answers[7][20], int nu
 /******************************************
   Filebrowser Module
 *****************************************/
-void fileBrowser(const char* browserTitle) {
+void fileBrowser(const __FlashStringHelper* browserTitle) {
   char fileNames[30][26];
   int currFile;
   filebrowse = 1;

--- a/Cart_Reader/FLASH.ino
+++ b/Cart_Reader/FLASH.ino
@@ -62,7 +62,7 @@ void flashMenu() {
   flashSlot = question_box("Select adapter PCB", menuOptions, 3, 0);
 #else
   convertPgm(menuOptionsFlash, 2);
-  flashSlot = question_box("Select adapter PCB", menuOptions, 2, 0);
+  flashSlot = question_box(F("Select adapter PCB"), menuOptions, 2, 0);
 #endif
 
   // wait for user choice to come back from the question box menu
@@ -101,7 +101,7 @@ void flashromMenu8() {
   unsigned char mainMenu;
   // Copy menuOptions out of progmem
   convertPgm(menuOptionsFLASH8, 7);
-  mainMenu = question_box("Flashrom Writer 8", menuOptions, 7, 0);
+  mainMenu = question_box(F("Flashrom Writer 8"), menuOptions, 7, 0);
 
   // wait for user choice to come back from the question box menu
   switch (mainMenu)
@@ -150,7 +150,7 @@ void flashromMenu8() {
     case 3:
       filePath[0] = '\0';
       sd.chdir("/");
-      fileBrowser("Select file");
+      fileBrowser(F("Select file"));
       display_Clear();
       time = millis();
       if (flashromType == 1)
@@ -239,7 +239,7 @@ void flashromMenu16() {
   unsigned char mainMenu;
   // Copy menuOptions out of progmem
   convertPgm(menuOptionsFLASH16, 7);
-  mainMenu = question_box("Flashrom Writer 16", menuOptions, 7, 0);
+  mainMenu = question_box(F("Flashrom Writer 16"), menuOptions, 7, 0);
 
   // wait for user choice to come back from the question box menu
   switch (mainMenu)
@@ -274,7 +274,7 @@ void flashromMenu16() {
     case 3:
       filePath[0] = '\0';
       sd.chdir("/");
-      fileBrowser("Select file");
+      fileBrowser(F("Select file"));
       display_Clear();
       time = millis();
       if (strcmp(flashid, "C2F3") == 0) {
@@ -335,7 +335,7 @@ void epromMenu() {
   unsigned char mainMenu;
   // Copy menuOptions out of progmem
   convertPgm(menuOptionsEprom, 6);
-  mainMenu = question_box("Eprom Writer", menuOptions, 6, 0);
+  mainMenu = question_box(F("Eprom Writer"), menuOptions, 6, 0);
 
   // wait for user choice to come back from the question box menu
   switch (mainMenu)
@@ -357,7 +357,7 @@ void epromMenu() {
     case 2:
       filePath[0] = '\0';
       sd.chdir("/");
-      fileBrowser("Select file");
+      fileBrowser(F("Select file"));
       display_Clear();
       time = millis();
       write_Eprom();
@@ -368,7 +368,7 @@ void epromMenu() {
     case 3:
       filePath[0] = '\0';
       sd.chdir("/");
-      fileBrowser("Verify against");
+      fileBrowser(F("Verify against"));
       sprintf(filePath, "%s/%s", filePath, fileName);
       display_Clear();
       time = millis();
@@ -1991,11 +1991,11 @@ void write_Eprom() {
           checkWord = writeWord_Eprom(currWord + c, myWord);
           // Check for fail
           if (n == 25) {
-            print_Msg("Program Error 0x");
+            print_Msg(F("Program Error 0x"));
             println_Msg(currWord + c, HEX);
-            print_Msg("0x");
+            print_Msg(F("0x"));
             print_Msg(readWord_Eprom(currWord + c), HEX);
-            print_Msg(" != 0x");
+            print_Msg(F(" != 0x"));
             println_Msg(myWord, HEX);
             print_Error(F("Press button to reset"), true);
           }

--- a/Cart_Reader/GB.ino
+++ b/Cart_Reader/GB.ino
@@ -34,7 +34,7 @@ void gbxMenu() {
   unsigned char gbType;
   // Copy menuOptions out of progmem
   convertPgm(menuOptionsGBx, 3);
-  gbType = question_box("Select Game Boy", menuOptions, 3, 0);
+  gbType = question_box(F("Select Game Boy"), menuOptions, 3, 0);
 
   // wait for user choice to come back from the question box menu
   switch (gbType)
@@ -67,7 +67,7 @@ void gbMenu() {
   unsigned char mainMenu;
   // Copy menuOptions out of progmem
   convertPgm(menuOptionsGB, 6);
-  mainMenu = question_box("GB Cart Reader", menuOptions, 6, 0);
+  mainMenu = question_box(F("GB Cart Reader"), menuOptions, 6, 0);
 
   // wait for user choice to come back from the question box menu
   switch (mainMenu)
@@ -590,7 +590,7 @@ void writeSRAM_GB() {
 
     filePath[0] = '\0';
     sd.chdir("/");
-    fileBrowser("Select sav file");
+    fileBrowser(F("Select sav file"));
     // Create filepath
     sprintf(filePath, "%s/%s", filePath, fileName);
 
@@ -712,7 +712,7 @@ void writeFlash_GB(byte MBC) {
   // Launch filebrowser
   filePath[0] = '\0';
   sd.chdir("/");
-  fileBrowser("Select file");
+  fileBrowser(F("Select file"));
   display_Clear();
 
   // Create filepath

--- a/Cart_Reader/GBA.ino
+++ b/Cart_Reader/GBA.ino
@@ -43,7 +43,7 @@ void gbaMenu() {
   unsigned char mainMenu;
   // Copy menuOptions out of progmem
   convertPgm(menuOptionsGBA, 6);
-  mainMenu = question_box("GBA Cart Reader", menuOptions, 6, 0);
+  mainMenu = question_box(F("GBA Cart Reader"), menuOptions, 6, 0);
 
   // wait for user choice to come back from the question box menu
   switch (mainMenu)
@@ -57,7 +57,7 @@ void gbaMenu() {
           unsigned char GBARomMenu;
           // Copy menuOptions out of progmem
           convertPgm(romOptionsGBA, 6);
-          GBARomMenu = question_box("Select ROM size", menuOptions, 6, 0);
+          GBARomMenu = question_box(F("Select ROM size"), menuOptions, 6, 0);
 
           // wait for user choice to come back from the question box menu
           switch (GBARomMenu)
@@ -138,7 +138,7 @@ void gbaMenu() {
         unsigned char GBASaveMenu;
         // Copy menuOptions out of progmem
         convertPgm(saveOptionsGBA, 6);
-        GBASaveMenu = question_box("Select save type", menuOptions, 6, 0);
+        GBASaveMenu = question_box(F("Select save type"), menuOptions, 6, 0);
 
         // wait for user choice to come back from the question box menu
         switch (GBASaveMenu)
@@ -242,7 +242,7 @@ void gbaMenu() {
         unsigned char GBASavesMenu;
         // Copy menuOptions out of progmem
         convertPgm(saveOptionsGBA, 6);
-        GBASavesMenu = question_box("Select save type", menuOptions, 6, 0);
+        GBASavesMenu = question_box(F("Select save type"), menuOptions, 6, 0);
         // wait for user choice to come back from the question box menu
         switch (GBASavesMenu)
         {
@@ -428,7 +428,7 @@ void gbaMenu() {
       unsigned char GBASaveMenu;
       // Copy menuOptions out of progmem
       convertPgm(saveOptionsGBA, 6);
-      GBASaveMenu = question_box("Select save type", menuOptions, 6, 0);
+      GBASaveMenu = question_box(F("Select save type"), menuOptions, 6, 0);
 
       // wait for user choice to come back from the question box menu
       switch (GBASaveMenu)
@@ -1015,7 +1015,7 @@ void writeSRAM_GBA(boolean browseFile, unsigned long sramSize, uint32_t pos) {
   if (browseFile) {
     filePath[0] = '\0';
     sd.chdir("/");
-    fileBrowser("Select srm file");
+    fileBrowser(F("Select srm file"));
     // Create filepath
     sprintf(filePath, "%s/%s", filePath, fileName);
     display_Clear();
@@ -1170,7 +1170,7 @@ void writeFRAM_GBA (boolean browseFile, unsigned long framSize) {
   if (browseFile) {
     filePath[0] = '\0';
     sd.chdir("/");
-    fileBrowser("Select srm file");
+    fileBrowser(F("Select srm file"));
     // Create filepath
     sprintf(filePath, "%s/%s", filePath, fileName);
     display_Clear();
@@ -1580,7 +1580,7 @@ void writeFLASH_GBA (boolean browseFile, unsigned long flashSize, uint32_t pos) 
   if (browseFile) {
     filePath[0] = '\0';
     sd.chdir("/");
-    fileBrowser("Select fla file");
+    fileBrowser(F("Select fla file"));
     // Create filepath
     sprintf(filePath, "%s/%s", filePath, fileName);
     display_Clear();
@@ -1692,7 +1692,7 @@ void writeEeprom_GBA(word eepSize) {
   // Launch Filebrowser
   filePath[0] = '\0';
   sd.chdir("/");
-  fileBrowser("Select eep file");
+  fileBrowser(F("Select eep file"));
   // Create filepath
   sprintf(filePath, "%s/%s", filePath, fileName);
   display_Clear();
@@ -2509,7 +2509,7 @@ void flashRepro_GBA() {
     // Launch file browser
     filePath[0] = '\0';
     sd.chdir("/");
-    fileBrowser("Select gba file");
+    fileBrowser(F("Select gba file"));
     display_Clear();
     display_Update();
 

--- a/Cart_Reader/MD.ino
+++ b/Cart_Reader/MD.ino
@@ -106,7 +106,7 @@ void mdMenu() {
   unsigned char mainMenu;
   // Copy menuOptions out of progmem
   convertPgm(menuOptionsMD, 7);
-  mainMenu = question_box("MEGA DRIVE Reader", menuOptions, 7, 0);
+  mainMenu = question_box(F("MEGA DRIVE Reader"), menuOptions, 7, 0);
 
   // wait for user choice to come back from the question box menu
   switch (mainMenu)
@@ -143,7 +143,7 @@ void mdMenu() {
         // Change working dir to root
         sd.chdir("/");
         // Launch file browser
-        fileBrowser("Select srm file");
+        fileBrowser(F("Select srm file"));
         display_Clear();
         enableSram_MD(1);
         writeSram_MD();
@@ -178,7 +178,7 @@ void mdMenu() {
       display_Clear();
       if (saveType == 4) {
         // Launch file browser
-        fileBrowser("Select eep file");
+        fileBrowser(F("Select eep file"));
         display_Clear();
         writeEEP_MD();
       }
@@ -191,7 +191,7 @@ void mdMenu() {
       // Change working dir to root
       filePath[0] = '\0';
       sd.chdir("/");
-      fileBrowser("Select file");
+      fileBrowser(F("Select file"));
       display_Clear();
       // Setting CS(PH3) LOW
       PORTH &= ~(1 << 3);
@@ -200,10 +200,10 @@ void mdMenu() {
       resetFlash_MD();
       idFlash_MD();
       resetFlash_MD();
-      print_Msg("Flash ID: ");
+      print_Msg(F("Flash ID: "));
       println_Msg(flashid);
       if (strcmp(flashid, "C2F1") == 0) {
-        println_Msg("MX29F1610 detected");
+        println_Msg(F("MX29F1610 detected"));
         flashSize = 2097152;
       }
       else {

--- a/Cart_Reader/N64.ino
+++ b/Cart_Reader/N64.ino
@@ -97,7 +97,7 @@ void n64Menu() {
   unsigned char n64Dev;
   // Copy menuOptions out of progmem
   convertPgm(menuOptionsN64, 4);
-  n64Dev = question_box("Select N64 device", menuOptions, 4, 0);
+  n64Dev = question_box(F("Select N64 device"), menuOptions, 4, 0);
 
   // wait for user choice to come back from the question box menu
   switch (n64Dev)
@@ -143,7 +143,7 @@ void n64ControllerMenu() {
   unsigned char mainMenu;
   // Copy menuOptions out of progmem
   convertPgm(menuOptionsN64Controller, 4);
-  mainMenu = question_box("N64 Controller", menuOptions, 4, 0);
+  mainMenu = question_box(F("N64 Controller"), menuOptions, 4, 0);
 
   // wait for user choice to come back from the question box menu
   switch (mainMenu)
@@ -171,7 +171,7 @@ void n64ControllerMenu() {
       filePath[0] = '\0';
       sd.chdir("/");
       // Launch file browser
-      fileBrowser("Select mpk file");
+      fileBrowser(F("Select mpk file"));
       display_Clear();
       display_Update();
       writeMPK();
@@ -194,7 +194,7 @@ void n64CartMenu() {
   unsigned char mainMenu;
   // Copy menuOptions out of progmem
   convertPgm(menuOptionsN64Cart, 5);
-  mainMenu = question_box("N64 Cart Reader", menuOptions, 5, 0);
+  mainMenu = question_box(F("N64 Cart Reader"), menuOptions, 5, 0);
 
   // wait for user choice to come back from the question box menu
   switch (mainMenu)
@@ -238,7 +238,7 @@ void n64CartMenu() {
       sd.chdir("/");
       if (saveType == 1) {
         // Launch file browser
-        fileBrowser("Select sra file");
+        fileBrowser(F("Select sra file"));
         display_Clear();
 
         writeSram(32768);
@@ -256,7 +256,7 @@ void n64CartMenu() {
       }
       else if (saveType == 4) {
         // Launch file browser
-        fileBrowser("Select fla file");
+        fileBrowser(F("Select fla file"));
         display_Clear();
         getFramType();
         writeFram(flashramType);
@@ -277,7 +277,7 @@ void n64CartMenu() {
       }
       else if ((saveType == 5) || (saveType == 6)) {
         // Launch file browser
-        fileBrowser("Select eep file");
+        fileBrowser(F("Select eep file"));
         display_Clear();
 
         writeEeprom();
@@ -306,7 +306,7 @@ void n64CartMenu() {
       unsigned char N64SaveMenu;
       // Copy menuOptions out of progmem
       convertPgm(saveOptionsN64, 5);
-      N64SaveMenu = question_box("Select save type", menuOptions, 5, 0);
+      N64SaveMenu = question_box(F("Select save type"), menuOptions, 5, 0);
 
       // wait for user choice to come back from the question box menu
       switch (N64SaveMenu)
@@ -753,7 +753,7 @@ void get_button()
   // Buttons (A,B,Z,S,DU,DD,DL,DR,0,0,L,R,CU,CD,CL,CR)
   if (rawStr.substring(0, 16) == "0000000000000000") {
     lastbutton = button;
-    button = "Press a button";
+    button = F("Press a button");
   }
   else
   {
@@ -765,59 +765,59 @@ void get_button()
         switch (i)
         {
           case 7:
-            button = "D-Right";
+            button = F("D-Right");
             break;
 
           case 6:
-            button = "D-Left";
+            button = F("D-Left");
             break;
 
           case 5:
-            button = "D-Down";
+            button = F("D-Down");
             break;
 
           case 4:
-            button = "D-Up";
+            button = F("D-Up");
             break;
 
           case 3:
-            button = "START";
+            button = F("START");
             break;
 
           case 2:
-            button = "Z";
+            button = F("Z");
             break;
 
           case 1:
-            button = "B";
+            button = F("B");
             break;
 
           case 0:
-            button = "A";
+            button = F("A");
             break;
 
           case 15:
-            button = "C-Right";
+            button = F("C-Right");
             break;
 
           case 14:
-            button = "C-Left";
+            button = F("C-Left");
             break;
 
           case 13:
-            button = "C-Down";
+            button = F("C-Down");
             break;
 
           case 12:
-            button = "C-Up";
+            button = F("C-Up");
             break;
 
           case 11:
-            button = "R";
+            button = F("R");
             break;
 
           case 10:
-            button = "L";
+            button = F("L");
             break;
         }
       }
@@ -848,7 +848,7 @@ void readController() {
     display_Update();
     delay(100);
 
-    if (button == "START") {
+    if (button == F("START")) {
       quit = 0;
     }
   }
@@ -1098,7 +1098,7 @@ void printCartInfo_N64() {
     unsigned char N64RomMenu;
     // Copy menuOptions out of progmem
     convertPgm(romOptionsN64, 6);
-    N64RomMenu = question_box("Select ROM size", menuOptions, 6, 0);
+    N64RomMenu = question_box(F("Select ROM size"), menuOptions, 6, 0);
 
     // wait for user choice to come back from the question box menu
     switch (N64RomMenu)
@@ -2150,11 +2150,7 @@ calcn64crc:
       // Copy menuOptions out of progmem
       convertPgm(menuOptionsN64CRC, 4);
 
-      char tempStr3[20];
-      strcpy(tempStr3, "CRC ERROR ");
-      strcat(tempStr3, crcStr);
-
-      CRCMenu = question_box(tempStr3, menuOptions, 4, 1);
+      CRCMenu = question_box(F("CRC ERROR "), menuOptions, 4, 1);
 
       // wait for user choice to come back from the question box menu
       switch (CRCMenu)
@@ -2259,7 +2255,7 @@ void flashRepro_N64() {
     // Launch file browser
     filePath[0] = '\0';
     sd.chdir("/");
-    fileBrowser("Select z64 file");
+    fileBrowser(F("Select z64 file"));
     display_Clear();
     display_Update();
 
@@ -3055,7 +3051,7 @@ void flashGameshark_N64() {
     // Launch file browser
     filePath[0] = '\0';
     sd.chdir("/");
-    fileBrowser("Select z64 file");
+    fileBrowser(F("Select z64 file"));
     display_Clear();
     display_Update();
 

--- a/Cart_Reader/NP.ino
+++ b/Cart_Reader/NP.ino
@@ -63,7 +63,7 @@ void sfmMenu() {
   unsigned char mainMenu;
   // Copy menuOptions out of progmem
   convertPgm(menuOptionsSFM, 3);
-  mainMenu = question_box("SF Memory", menuOptions, 3, 0);
+  mainMenu = question_box(F("SF Memory"), menuOptions, 3, 0);
 
   // wait for user choice to come back from the question box menu
   switch (mainMenu)
@@ -101,7 +101,7 @@ void sfmGameMenu() {
       // Create menu with title and numGames options to choose from
       unsigned char gameSubMenu;
       // wait for user choice to come back from the question box menu
-      gameSubMenu = question_box("Select Game", menuOptionsSFMGames, numGames, 0);
+      gameSubMenu = question_box(F("Select Game"), menuOptionsSFMGames, numGames, 0);
 
       // Switch to game
       send_SFM(gameSubMenu + 0x80);
@@ -156,7 +156,7 @@ void sfmGameOptions() {
   unsigned char gameSubMenu;
   // Copy menuOptions out of progmem
   convertPgm(menuOptionsSFMGame, 5);
-  gameSubMenu = question_box("SFM Game Menu", menuOptions, 5, 0);
+  gameSubMenu = question_box(F("SFM Game Menu"), menuOptions, 5, 0);
 
   // wait for user choice to come back from the question box menu
   switch (gameSubMenu)
@@ -221,7 +221,7 @@ void sfmFlashMenu() {
   unsigned char flashSubMenu;
   // Copy menuOptions out of progmem
   convertPgm(menuOptionsSFMFlash, 6);
-  flashSubMenu = question_box("SFM Flash Menu", menuOptions, 6, 0);
+  flashSubMenu = question_box(F("SFM Flash Menu"), menuOptions, 6, 0);
 
   // wait for user choice to come back from the question box menu
   switch (flashSubMenu)
@@ -288,7 +288,7 @@ void sfmFlashMenu() {
       filePath[0] = '\0';
       sd.chdir("/");
       // Launch file browser
-      fileBrowser("Select 4MB file");
+      fileBrowser(F("Select 4MB file"));
       display_Clear();
       sprintf(filePath, "%s/%s", filePath, fileName);
       flashSize = 2097152;
@@ -431,7 +431,7 @@ void sfmFlashMenu() {
       sd.chdir("/");
 
       // Launch file browser
-      fileBrowser("Select MAP file");
+      fileBrowser(F("Select MAP file"));
       display_Clear();
       sprintf(filePath, "%s/%s", filePath, fileName);
       display_Update();
@@ -1476,7 +1476,7 @@ void gbmMenu() {
   unsigned char mainMenu;
   // Copy menuOptions out of progmem
   convertPgm(menuOptionsGBM, 7);
-  mainMenu = question_box("GB Memory Menu", menuOptions, 7, 0);
+  mainMenu = question_box(F("GB Memory Menu"), menuOptions, 7, 0);
 
   // wait for user choice to come back from the question box menu
   switch (mainMenu)
@@ -1559,7 +1559,7 @@ void gbmMenu() {
       filePath[0] = '\0';
       sd.chdir("/");
       // Launch file browser
-      fileBrowser("Select 1MB file");
+      fileBrowser(F("Select 1MB file"));
       display_Clear();
       sprintf(filePath, "%s/%s", filePath, fileName);
 
@@ -1608,7 +1608,7 @@ void gbmMenu() {
       sd.chdir("/");
 
       // Launch file browser
-      fileBrowser("Select MAP file");
+      fileBrowser(F("Select MAP file"));
       display_Clear();
       sprintf(filePath, "%s/%s", filePath, fileName);
       display_Update();

--- a/Cart_Reader/PCE.ino
+++ b/Cart_Reader/PCE.ino
@@ -115,7 +115,7 @@ void pcsMenu(void) {
   unsigned char pceDev;
   // Copy menuOptions out of progmem
   convertPgm(menuOptionspce, 2);
-  pceDev = question_box("Select device", menuOptions, 2, 0);
+  pceDev = question_box(F("Select device"), menuOptions, 2, 0);
 
   // wait for user choice to come back from the question box menu
   switch (pceDev)
@@ -521,7 +521,7 @@ void crc_search(char *file_p, char *folder_p, uint32_t rom_size)
       flag = CHKSUM_ERROR;
       crc = 0xFFFFFFFFUL; //Initialize CRC
       display_Clear();
-      println_Msg("Calculating chksum...");
+      println_Msg(F("Calculating chksum..."));
       processedsize = 0;
       draw_progressbar(0, rom_size * 1024UL); //Initialize progress bar
 
@@ -549,7 +549,7 @@ void crc_search(char *file_p, char *folder_p, uint32_t rom_size)
         //if checksum search successful, rename the file and end search
         if (strcmp(crc_search, crc_file) == 0)
         {
-          print_Msg("Chksum OK ");
+          print_Msg(F("Chksum OK "));
           println_Msg(crc_file);
           print_Msg(F("Saved to "));
           print_Msg(folder_p);
@@ -576,7 +576,7 @@ void crc_search(char *file_p, char *folder_p, uint32_t rom_size)
   }
   else if (flag == CHKSUM_ERROR)
   {
-    print_Msg("Chksum Error ");
+    print_Msg(F("Chksum Error "));
     println_Msg(crc_file);
     print_Msg(F("Saved to "));
     print_Msg(folder_p);
@@ -598,8 +598,7 @@ void read_tennokoe_bank_PCE(void)
   //clear the screen
   display_Clear();
   
-  sprintf(fileName, "RAM size: 8KB"); //using filename global variable as string. Initialzed in below anyways.
-  println_Msg(fileName);
+  println_Msg(F("RAM size: 8KB"));
 
   // Get name, add extension and convert to char array for sd lib
   strcpy(fileName, "BANKRAM");
@@ -683,7 +682,7 @@ void write_tennokoe_bank_PCE(void)
   //Display file Browser and wait user to select a file. Size must be 8KB.
   filePath[0] = '\0';
   sd.chdir("/");
-  fileBrowser("Select RAM file");
+  fileBrowser(F("Select RAM file"));
   // Create filepath
   sprintf(filePath, "%s/%s", filePath, fileName);
   display_Clear();
@@ -766,8 +765,9 @@ void read_rom_PCE(void)
   display_Clear();
   rom_size = detect_rom_size_PCE();
   
-  sprintf(fileName, "Detected size: %dKB", rom_size); //using filename global variable as string. Initialzed in below anyways.
-  println_Msg(fileName);
+  print_Msg(F("Detected size: "));
+  print_Msg(rom_size);
+  println_Msg(F("KB"));
 
   // Get name, add extension and convert to char array for sd lib
   strcpy(fileName, "PCEROM");
@@ -834,7 +834,7 @@ void read_rom_PCE(void)
 
 
 
-// SNES Menu
+// PC Engine Menu
 void pceMenu() {
   // create menu with title and 7 options to choose from
   unsigned char mainMenu;
@@ -843,7 +843,7 @@ void pceMenu() {
   {
     // Copy menuOptions out of progmem
     convertPgm(menuOptionspceCart, 4);
-    mainMenu = question_box("PCE HuCARD menu", menuOptions, 4, 0);
+    mainMenu = question_box(F("PCE HuCARD menu"), menuOptions, 4, 0);
 
     // wait for user choice to come back from the question box menu
     switch (mainMenu)
@@ -871,7 +871,7 @@ void pceMenu() {
   {
     // Copy menuOptions out of progmem
     convertPgm(menuOptionspceTC, 2);
-    mainMenu = question_box("TG TurboChip menu", menuOptions, 2, 0);
+    mainMenu = question_box(F("TG TurboChip menu"), menuOptions, 2, 0);
 
     // wait for user choice to come back from the question box menu
     switch (mainMenu)

--- a/Cart_Reader/SNES.ino
+++ b/Cart_Reader/SNES.ino
@@ -60,7 +60,7 @@ void snsMenu() {
   unsigned char snsCart;
   // Copy menuOptions out of progmem
   convertPgm(menuOptionsSNS, 5);
-  snsCart = question_box("Select Cart Type", menuOptions, 5, 0);
+  snsCart = question_box(F("Select Cart Type"), menuOptions, 5, 0);
 
   // wait for user choice to come back from the question box menu
   switch (snsCart)
@@ -114,7 +114,7 @@ void snesMenu() {
   unsigned char mainMenu;
   // Copy menuOptions out of progmem
   convertPgm(menuOptionsSNES, 6);
-  mainMenu = question_box("SNES Cart Reader", menuOptions, 6, 0);
+  mainMenu = question_box(F("SNES Cart Reader"), menuOptions, 6, 0);
 
   // wait for user choice to come back from the question box menu
   switch (mainMenu)
@@ -209,7 +209,7 @@ void snesMenu() {
       // Switch RST(PH0) to LOW
       PORTH &= ~(1 << 0);
       display_Clear();
-      print_Msg("Resetting...");
+      print_Msg(F("Resetting..."));
       display_Update();
       delay(3000);  // wait 3 secs to switch to next game
       resetArduino();
@@ -231,7 +231,7 @@ void confMenu() {
   unsigned char subMenu;
   // Copy menuOptions out of progmem
   convertPgm(menuOptionsConf, 5);
-  subMenu = question_box("Choose mapping", menuOptions, 5, 0);
+  subMenu = question_box(F("Choose mapping"), menuOptions, 5, 0);
 
   // wait for user choice to come back from the question box menu
   switch (subMenu)
@@ -1183,7 +1183,7 @@ void writeSRAM (boolean browseFile) {
   if (browseFile) {
     filePath[0] = '\0';
     sd.chdir("/");
-    fileBrowser("Select srm file");
+    fileBrowser(F("Select srm file"));
     // Create filepath
     sprintf(filePath, "%s/%s", filePath, fileName);
     display_Clear();
@@ -1672,7 +1672,7 @@ unsigned long verifySRAM() {
       // Switch RST(PH0) to LOW
       PORTH &= ~(1 << 0);
       display_Clear();
-      print_Msg("Resetting...");
+      print_Msg(F("Resetting..."));
       display_Update();
       delay(3000);  // wait 3 secs
       resetArduino();

--- a/Cart_Reader/SV.ino
+++ b/Cart_Reader/SV.ino
@@ -42,7 +42,7 @@ void svMenu() {
   unsigned char mainMenu;
   // Copy menuOptions out of progmem
   convertPgm(menuOptionsSVFlash, 3);
-  mainMenu = question_box("Satellaview 8M Memory", menuOptions, 3, 0);
+  mainMenu = question_box(F("Satellaview 8M Memory"), menuOptions, 3, 0);
 
   // wait for user choice to come back from the question box menu
   switch (mainMenu)
@@ -214,7 +214,7 @@ void writeROM_SV (void) {
   //Display file Browser and wait user to select a file. Size must be 1MB.
   filePath[0] = '\0';
   sd.chdir("/");
-  fileBrowser("Select sfc file");
+  fileBrowser(F("Select sfc file"));
   // Create filepath
   sprintf(filePath, "%s/%s", filePath, fileName);
   display_Clear();


### PR DESCRIPTION
conserve ~ 800 byte SRAM by putting menu strings in progmem. 
Free bytes now: ~ 4000

I reduced one dynamic string that combines a crc with a question_box title to just the static title.
The crc is shown before that though, so I figure it's fine.

This is a large change but sram is precious. 
Future question_box titles will be progmem strings only as well.