### PR TITLE
n64_speedup

### DIFF
--- a/Cart_Reader/Cart_Reader.ino
+++ b/Cart_Reader/Cart_Reader.ino
@@ -146,6 +146,11 @@ SdFile myFile;
 #define mode_SV 14
 
 /******************************************
+   optimization-safe nop delay
+ *****************************************/
+#define NOP __asm__ __volatile__ ("nop\n\t")
+
+/******************************************
    Variables
  *****************************************/
 // Button timing

--- a/Cart_Reader/GB.ino
+++ b/Cart_Reader/GB.ino
@@ -449,7 +449,7 @@ void readROM_GB() {
 
 unsigned int calc_checksum_GB (char* fileName, char* folder) {
   unsigned int calcChecksum = 0;
-  int calcFilesize = 0;
+//  int calcFilesize = 0; // unused
   unsigned long i = 0;
   int c = 0;
 
@@ -458,7 +458,7 @@ unsigned int calc_checksum_GB (char* fileName, char* folder) {
 
   // If file exists
   if (myFile.open(fileName, O_READ)) {
-    calcFilesize = myFile.fileSize() * 8 / 1024 / 1024;
+    //calcFilesize = myFile.fileSize() * 8 / 1024 / 1024; // unused
     for (i = 0; i < (myFile.fileSize() / 512); i++) {
       myFile.read(sdBuffer, 512);
       for (c = 0; c < 512; c++) {
@@ -959,7 +959,7 @@ void writeFlash_GB(byte MBC) {
 
     // Go back to file beginning
     myFile.seekSet(0);
-    unsigned int addr = 0;
+    //unsigned int addr = 0;  // unused
     writeErrors = 0;
 
     // Verify flashrom

--- a/Cart_Reader/GBA.ino
+++ b/Cart_Reader/GBA.ino
@@ -768,8 +768,6 @@ void getCartInfo_GBA() {
   else {
     char tempStr2[2];
     char tempStr[5];
-    char sizeStr[3];
-    char saveStr[2];
 
     // cart not in list
     cartSize = 0;

--- a/Cart_Reader/PCE.ino
+++ b/Cart_Reader/PCE.ino
@@ -36,7 +36,7 @@ void pin_init_PCE(void);
 void setup_cart_PCE(void);
 void reset_cart_PCE(void);
 uint8_t read_byte_PCE(uint32_t address);
-uint8_t write_byte_PCE(uint32_t address, uint8_t data);
+void write_byte_PCE(uint32_t address, uint8_t data);
 uint32_t detect_rom_size_PCE(void);
 void read_bank_PCE(uint32_t address_start, uint32_t address_end, uint32_t *processed_size, uint32_t total_size);
 void read_rom_PCE(void);
@@ -233,7 +233,6 @@ void set_address_PCE(uint32_t address)
 uint8_t read_byte_PCE(uint32_t address)
 {
   uint8_t ret;
-  uint8_t address_byte;
 
   set_address_PCE(address);
 
@@ -265,11 +264,8 @@ uint8_t read_byte_PCE(uint32_t address)
 
 }
 
-uint8_t write_byte_PCE(uint32_t address, uint8_t data)
+void write_byte_PCE(uint32_t address, uint8_t data)
 {
-  uint8_t ret;
-  uint8_t address_byte;
-
   set_address_PCE(address);
 
   // Arduino running at 16Mhz -> one nop = 62.5ns -> 1000ns total
@@ -303,10 +299,6 @@ uint8_t write_byte_PCE(uint32_t address, uint8_t data)
 
   // Enable Internal Pullups
   PORTC = 0xFF;
-
-  //return read data
-  return ret;
-
 }
 
 //Confirm the size of ROM - 128Kb, 256Kb, 384Kb, 512Kb, 768Kb or 1024Kb

--- a/Cart_Reader/SNES.ino
+++ b/Cart_Reader/SNES.ino
@@ -11,8 +11,6 @@
 #define HI 1
 #define LO 0
 
-// optimization-safe nop delay
-#define NOP __asm__ __volatile__ ("nop\n\t")
 /******************************************
    Variables
  *****************************************/
@@ -613,8 +611,6 @@ void getCartInfo_SNES() {
 void checkAltConf() {
   char tempStr1[2];
   char tempStr2[5];
-  char sizeStr[3];
-  char bankStr[3];
 
   if (myFile.open("snes.txt", O_READ)) {
     while (myFile.available()) {


### PR DESCRIPTION
roughly double n64 dumping performance by using the 1024 byte file buffer and combining the checksum and dumping code; also some cleanup

The dumper routine can probably do the crc32 calculations instead of the 310ns NOP delay.
For that I'd first like to check the timings with a logic analyzer first though.
But the crc32 code is surely longer than 310ns, I think :)