### PR TITLE
SNES, MD: avoid dumping/writing 0 Byte files to SD card

### DIFF
--- a/Cart_Reader/MD.ino
+++ b/Cart_Reader/MD.ino
@@ -195,10 +195,18 @@ void mdCartMenu() {
   {
     case 0:
       display_Clear();
-      // Change working dir to root
-      sd.chdir("/");
-      readROM_MD();
-      //compare_checksum_MD();
+
+      // common ROM read fail state: no cart inserted - tends to report impossibly large cartSize
+      // largest known game so far is supposedly "Paprium" at 10MB, so cap sanity check at 16MB
+      if (cartSize != 0 && cartSize <= 16777216) {
+        // Change working dir to root
+        sd.chdir("/");
+        readROM_MD();
+        //compare_checksum_MD();
+      }
+      else {
+        print_Error(F("Cart has no ROM"), false);
+      }
       break;
 
     case 1:

--- a/Cart_Reader/N64.ino
+++ b/Cart_Reader/N64.ino
@@ -298,6 +298,7 @@ void n64CartMenu() {
         }
       }
       else {
+        display_Clear();
         print_Error(F("Savetype Error"), false);
       }
       println_Msg(F("Press Button..."));


### PR DESCRIPTION
I've only checked and dealt with SNES, MD and N64.
It'd be nice to avoid writing all kinds of bad files to SD card, so that users can be confident that everything that IS on a card is also valid.