### PR TITLE
modular compilation fixes

### DIFF
--- a/Cart_Reader/Cart_Reader.ino
+++ b/Cart_Reader/Cart_Reader.ino
@@ -399,6 +399,10 @@ static const uint32_t crc_32_tab[] PROGMEM = { /* CRC polynomial 0xedb88320 */
   0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d
 };
 
+// used by MD and NES modules
+byte eepbit[8];
+byte eeptemp;
+
 /******************************************
   Menu
 *****************************************/
@@ -1577,9 +1581,11 @@ void loop() {
     gbmMenu();
   }
 #endif
+#ifdef enable_MD
   else if (mode == mode_MD_Cart) {
     mdCartMenu();
   }
+#endif
 #ifdef enable_PCE
   else if (mode == mode_PCE) {
     pceMenu();

--- a/Cart_Reader/MD.ino
+++ b/Cart_Reader/MD.ino
@@ -10,9 +10,7 @@
    Variables
  *****************************************/
 unsigned long sramEnd;
-byte eepbit[8];
 int eepSize;
-byte eeptemp;
 word addrhi;
 word addrlo;
 word chksum;
@@ -80,7 +78,6 @@ static const word PROGMEM eepid [] = {
 };
 
 byte eepcount = (sizeof(eepid) / sizeof(eepid[0])) / 2;
-int index;
 word eepdata;
 
 // CD BACKUP RAM
@@ -542,7 +539,7 @@ void getCartInfo_MD() {
 
   // Serial EEPROM Check
   for (int i = 0; i < eepcount; i++) {
-    index = i * 2;
+    int index = i * 2;
     word eepcheck = pgm_read_word(eepid + index);
     if (eepcheck == chksum) {
       eepdata = pgm_read_word(eepid + index + 1);

--- a/Cart_Reader/NES.ino
+++ b/Cart_Reader/NES.ino
@@ -938,7 +938,7 @@ setmapper:
   mapfound = false;
   Serial.println(F("SUPPORTED MAPPERS:"));
   for (int i = 0; i < mapcount; i++) {
-    index = i * 7;
+    int index = i * 7;
     mapselect = pgm_read_byte(mapsize + index);
     Serial.print("[");
     Serial.print(mapselect);
@@ -958,7 +958,7 @@ setmapper:
   Serial.println(newmap);
   newmapper = newmap.toInt();
   for (int i = 0; i < mapcount; i++) {
-    index = i * 7;
+    int index = i * 7;
     mapselect = pgm_read_byte(mapsize + index);
     if (newmapper == mapselect)
       mapfound = true;
@@ -976,7 +976,7 @@ setmapper:
 
 void checkMapperSize() {
   for (int i = 0; i < mapcount; i++) {
-    index = i * 7;
+    int index = i * 7;
     byte mapcheck = pgm_read_byte(mapsize + index);
     if (mapcheck == mapper) {
       prglo = pgm_read_byte(mapsize + index + 1);

--- a/Cart_Reader/SNES.ino
+++ b/Cart_Reader/SNES.ino
@@ -75,12 +75,14 @@ void snsMenu() {
       mode = mode_SNES;
       break;
 
+#ifdef enable_NP
     case 1:
       display_Clear();
       display_Update();
       setup_SFM();
       mode = mode_SFM;
       break;
+#endif
 
     case 2:
       display_Clear();


### PR DESCRIPTION
There were three global variables used in both MD.ino and NES.ino:
* int index  -> changed to use local variables
* byte eepbit[8];  byte eeptemp;   -> moved to Cart_Reader.ino

Other changes:
* add #ifdef enable_NP around call to setup_SFM  (in SNES.ino)
* add #ifdef enable_MD around call to mdCartMenu (in Cart_Reader.ino)
