### PR TITLE
Load SNES clock generator offset from SD card

### DIFF
--- a/Cart_Reader/NP.ino
+++ b/Cart_Reader/NP.ino
@@ -4,6 +4,7 @@
 
 #include "options.h"
 #ifdef enable_NP
+#include "snes_clk.h"
 
 /******************************************
    SF Memory Clock Source
@@ -605,7 +606,12 @@ void setup_SFM() {
   //PORTH &= ~(1 << 1);
 
   // Adafruit Clock Generator
-  clockgen.init(SI5351_CRYSTAL_LOAD_8PF, 0, 0);
+  int32_t clock_offset = readClockOffset();
+  if (clock_offset > INT32_MIN) {
+    clockgen.init(SI5351_CRYSTAL_LOAD_8PF, 0, clock_offset);
+  } else {
+    clockgen.init(SI5351_CRYSTAL_LOAD_8PF, 0, -16000);
+  }
   clockgen.set_pll(SI5351_PLL_FIXED, SI5351_PLLA);
   clockgen.set_pll(SI5351_PLL_FIXED, SI5351_PLLB);
   clockgen.set_freq(2147727200ULL, SI5351_CLK0);

--- a/Cart_Reader/SNES.ino
+++ b/Cart_Reader/SNES.ino
@@ -4,6 +4,7 @@
 
 #include "options.h"
 #ifdef enable_SNES
+#include "snes_clk.h"
 
 /******************************************
   Defines
@@ -382,7 +383,12 @@ void setup_Snes() {
 
   // Adafruit Clock Generator
   // last number is the clock correction factor which is custom for each clock generator
-  clockgen.init(SI5351_CRYSTAL_LOAD_8PF, 0, -16000);
+  int32_t clock_offset = readClockOffset();
+  if (clock_offset > INT32_MIN) {
+    clockgen.init(SI5351_CRYSTAL_LOAD_8PF, 0, clock_offset);
+  } else {
+    clockgen.init(SI5351_CRYSTAL_LOAD_8PF, 0, -16000);
+  }
 
   // Set clocks to 4Mhz/1Mhz for better SA-1 unlocking
   clockgen.set_freq(100000000ULL, SI5351_CLK1); // CPU

--- a/Cart_Reader/snes_clk.cpp
+++ b/Cart_Reader/snes_clk.cpp
@@ -15,7 +15,7 @@ int32_t readClockOffset() {
 	clock_file.close();
 	if(i == -1) {
 		free(clock_buf);
-		return 0;
+		return INT32_MIN;
 	} else if(i < 16) {
 		clock_buf[i] = 0;
 	}

--- a/Cart_Reader/snes_clk.cpp
+++ b/Cart_Reader/snes_clk.cpp
@@ -1,0 +1,27 @@
+#include "snes_clk.h"
+#include <SdFat.h>
+
+int32_t readClockOffset() {
+	File clock_file;
+	unsigned char* clock_buf;
+	int16_t i;
+	int32_t clock_offset;
+	if(!clock_file.open("/snes_clk.txt", FILE_READ)) {
+		return INT32_MIN;
+	}
+
+	clock_buf = malloc(16 * sizeof(char));
+	i = clock_file.read(clock_buf, 16);
+	clock_file.close();
+	if(i == -1) {
+		free(clock_buf);
+		return 0;
+	} else if(i < 16) {
+		clock_buf[i] = 0;
+	}
+
+	clock_offset = (int32_t)atoi(clock_buf);
+	free(clock_buf);
+
+	return clock_offset;
+}

--- a/Cart_Reader/snes_clk.h
+++ b/Cart_Reader/snes_clk.h
@@ -1,0 +1,8 @@
+#ifndef _SNES_CLK_H
+#define _SNES_CLK_H
+
+#include <SdFat.h>
+
+int32_t readClockOffset();
+
+#endif


### PR DESCRIPTION
This adds a check for a file named "snes_clk.txt" in the root of the SD card and loads the clock offset from it (16 characters max for the offset).  This will allow people to keep a file on there with the offset they need for their particular clock generator and not have to worry about editing the sketches each time a new version comes out.