### PR TITLE
SMS: add a strange checksum from The Pro Yakyuu '91 (Game Gear).

### DIFF
--- a/Cart_Reader/SMS.ino
+++ b/Cart_Reader/SMS.ino
@@ -312,6 +312,10 @@ void getCartInfo_SMS() {
     case 0x2:
       cartSize =  512 * 1024UL;
       break;
+    case 0x3:
+      // 0x3 is (only?) used in The Pro Yakyuu '91 (Game Gear)
+      cartSize =  128 * 1024UL;
+      break;
     default:
       cartSize =  48 * 1024UL;
       // LED Error


### PR DESCRIPTION
I tried to dump The Pro Yakyuu '91 (Game Gear), this game is 128KB (1Mbit), but the nibble of 0x7FFF is 0x3. I found this by temporarily setting the default to 128KB and successfully dumping it.
I couldn't find any other information about titles that use 0x3, but this value seems to be correct for this title (consistent with the No-Intro database).