### PR TITLE
Fixed build warnings

### DIFF
--- a/Cart_Reader/GB.ino
+++ b/Cart_Reader/GB.ino
@@ -1411,7 +1411,7 @@ void identifyCFI_GB() {
       println_Msg(F("CFI Query failed!"));
       display_Update();
       wait();
-      return 0;
+      return;
     }
   }
   dataIn_GB();

--- a/Cart_Reader/NES.ino
+++ b/Cart_Reader/NES.ino
@@ -851,7 +851,7 @@ unsigned char* getNESHeaderForFileInfo(uint32_t prg_size, uint32_t chr_size, uin
   }
 
   char* temp_line;
-  char* nes20_header;
+  unsigned char* nes20_header;
   int i;
 
   if (!sdFile.open("/nes20db.txt", FILE_READ)) {
@@ -862,7 +862,7 @@ unsigned char* getNESHeaderForFileInfo(uint32_t prg_size, uint32_t chr_size, uin
     display_Update();
   }
 
-  temp_line = malloc(256 * sizeof(char));
+  temp_line = (char*)malloc(256 * sizeof(char));
   while (sdFile.available()) {
     // We're reading fixed-length lines
     // padded with null characters

--- a/Cart_Reader/PCE.ino
+++ b/Cart_Reader/PCE.ino
@@ -67,7 +67,7 @@ static const char pceCartMenuItem4[] = "Reset";
 static const char pceCartMenuItem5[] = "Inc Bank Number";
 static const char pceCartMenuItem6[] = "Dec Bank Number";
 static char pceCartMenuItem7[20];
-static const char menuOptionspceCart[7][20];
+static char menuOptionspceCart[7][20];
 
 // Turbochip menu items
 static const char pceTCMenuItem1[] PROGMEM = "Read ROM";

--- a/Cart_Reader/SMS.ino
+++ b/Cart_Reader/SMS.ino
@@ -528,8 +528,8 @@ void writeSRAM_SMS() {
     if (myFile.open(filePath, O_READ)) {
       // Get SRAM size from file, with a maximum of 32KB
       uint32_t sramSize = myFile.fileSize();
-      if (sramSize > (32 * 1024)) {
-        sramSize = 32 * 1024;
+      if (sramSize > ((uint32_t)32 * (uint32_t)1024)) {
+        sramSize = (uint32_t)32 * (uint32_t)1024;
       }
       print_Msg(F("sramSize: "));
       print_Msg(sramSize);

--- a/Cart_Reader/snes_clk.cpp
+++ b/Cart_Reader/snes_clk.cpp
@@ -4,7 +4,7 @@
 
 int32_t readClockOffset() {
   FsFile clock_file;
-  unsigned char* clock_buf;
+  char* clock_buf;
   int16_t i;
   int32_t clock_offset;
 
@@ -12,7 +12,7 @@ int32_t readClockOffset() {
     return INT32_MIN;
   }
 
-  clock_buf = malloc(12 * sizeof(char));
+  clock_buf = (char*)malloc(12 * sizeof(char));
   i = clock_file.read(clock_buf, 11);
   clock_file.close();
   if (i == -1) {


### PR DESCRIPTION
I noticed a number of build warnings in the code (including some overflow warnings in the SMS module; I guess the default number representation is small enough that 32768 doesn't fit in the allocation), so this should resolve them.