### PR TITLE
Add github actions workflow to build code for each HW rev. on each push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,48 @@
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      hwVersion:
+        description: "The version of the hardware to compile for (e.g. HW5, HW4, ...)"
+        required: true
+        type: string
+
+env:
+  ARDUINO_LIBRARY_ENABLE_UNSAFE_INSTALL: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Arduino CLI
+        uses: arduino/setup-arduino-cli@v1
+
+      - name: Install platform
+        run: |
+          arduino-cli core update-index
+          arduino-cli core install arduino:avr
+
+      - name: Install libraries
+        run: |
+          arduino-cli lib install \
+            "SdFat" \
+            "Adafruit SSD1306" \
+            "Adafruit GFX Library" \
+            "Adafruit BusIO" \
+            "U8g2" \
+            "Adafruit NeoPixel" \
+            "RotaryEncoder" \
+            "Etherkit Si5351" \
+            "RTClib" \
+            "FreqCount"
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Compile
+        run: |
+          cd Cart_Reader/
+          # Select hardware version by uncommenting it (using regular expression)
+          sed -i 's/^\/\/[\t ]*#define ${{ inputs.hwVersion }}/#define ${{ inputs.hwVersion }}/g' Cart_Reader.ino
+          arduino-cli compile --fqbn arduino:avr:mega

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on: [push]
+
+jobs:
+  HW5:
+    uses: ./.github/workflows/build.yml
+    with:
+      hwVersion: "HW5"
+
+  HW4:
+    uses: ./.github/workflows/build.yml
+    with:
+      hwVersion: "HW4"
+
+  HW3:
+    uses: ./.github/workflows/build.yml
+    with:
+      hwVersion: "HW3"
+
+  HW2:
+    uses: ./.github/workflows/build.yml
+    with:
+      hwVersion: "HW2"
+
+  HW1:
+    uses: ./.github/workflows/build.yml
+    with:
+      hwVersion: "HW1"


### PR DESCRIPTION
This PR adds a github workflow which enables building the project on github on each push.

To build the project, ``arduino-cli`` is used (on an Ubuntu runner). It should give the same result as compiling the project using the portable IDE shipped with each release. All the required libraries are included using ``arduino-cli lib install``. The code is compiled separately for each hardware revision.
Having a central builder can help finding problems before merging.
Currently the code is only build and the only outcome is to see if the code compiles. In the future, maybe binaries can be build automatically for releases, so that users can directly download a binary file of the firmware and flash it so you don't need to compile the code yourself and you don't need windows to compile.

To automatically select the hardware revision the tool ``sed`` is used which uncomments the corresponding define. In the future, maybe an extra file can be used for the define, so that editing the code automatically is not necessary.