### PR TITLE
Display full ROM title for GB and GBA and more mapper names for GB

### DIFF
--- a/Cart_Reader/GB.ino
+++ b/Cart_Reader/GB.ino
@@ -418,9 +418,15 @@ void showCartInfo_GB() {
       print_Msg(F("MBC4"));
     else if ((romType == 25) || (romType == 26) || (romType == 27) || (romType == 28) || (romType == 29) || (romType == 309))
       print_Msg(F("MBC5"));
-    if (romType == 252)
+    else if (romType == 34)
+      print_Msg(F("MBC7"));
+    else if (romType == 252)
       print_Msg(F("Camera"));
-
+    else if (romType == 254)
+      print_Msg(F("HuC-3"));
+    else if (romType == 255)
+      print_Msg(F("HuC-1"));
+    
     println_Msg(F(" "));
     print_Msg(F("Rom Size: "));
     switch (romSize) {

--- a/Cart_Reader/GB.ino
+++ b/Cart_Reader/GB.ino
@@ -787,10 +787,16 @@ void getCartInfo_GB() {
 
   // Get name
   byte myLength = 0;
-
-  for (int addr = 0x0134; addr <= 0x13C; addr++) {
-    if (((char(sdBuffer[addr]) >= 48 && char(sdBuffer[addr]) <= 57) || (char(sdBuffer[addr]) >= 65 && char(sdBuffer[addr]) <= 122)) && myLength < 15) {
+  byte x = 0;
+  if (sdBuffer[0x143] == 0x80 || sdBuffer[0x143] == 0xC0) {
+    x++;
+  }
+  for (int addr = 0x0134; addr <= 0x0143-x; addr++) {
+    if (isprint(sdBuffer[addr]) && sdBuffer[addr] != '<' && sdBuffer[addr] != '>' && sdBuffer[addr] != ':' && sdBuffer[addr] != '"' && sdBuffer[addr] != '/' && sdBuffer[addr] != '\\' && sdBuffer[addr] != '|' && sdBuffer[addr] != '?' && sdBuffer[addr] != '*') {
       romName[myLength] = char(sdBuffer[addr]);
+      myLength++;
+    } else if (char(sdBuffer[addr]) != 0) {
+      romName[myLength] = 0x5F;
       myLength++;
     }
   }

--- a/Cart_Reader/GBA.ino
+++ b/Cart_Reader/GBA.ino
@@ -895,8 +895,11 @@ void getCartInfo_GBA() {
     byte myLength = 0;
     for (int addr = 0xA0; addr <= 0xAB; addr++) {
       myByte = sdBuffer[addr];
-      if (((char(myByte) >= 48 && char(myByte) <= 57) || (char(myByte) >= 65 && char(myByte) <= 122)) && myLength < 15) {
+      if (isprint(myByte) && myByte != '<' && myByte != '>' && myByte != ':' && myByte != '"' && myByte != '/' && myByte != '\\' && myByte != '|' && myByte != '?' && myByte != '*') {
         romName[myLength] = char(myByte);
+        myLength++;
+      } else if (char(sdBuffer[addr]) != 0) {
+        romName[myLength] = 0x5F;
         myLength++;
       }
     }


### PR DESCRIPTION
Displays better names for Game Boy games, e.g. `KIRBYSP` will now show up as `KIRBY'S PINBALL`. Non-printable characters and those not valid for filenames (`<>:"/\|?*`) are replaced by underscores, null characters are still skipped.

For Game Boy, names of mappers `MBC7`, `HuC-1` and `HuC-3` will also be displayed as these are currently supported at least for ROM reading.