### PR TITLE
Use correct mapper type for GB Mani 4 in 1

### DIFF
--- a/Cart_Reader/GB.ino
+++ b/Cart_Reader/GB.ino
@@ -818,9 +818,18 @@ void getCartInfo_GB() {
     myLength--;
   }
 
-  // Detect M161 game
-  if ((strncmp(romName, "TETRIS SET", 9) == 0) && (sdBuffer[0x14D] == 0x3F)) {
+  // M161 (Mani 4 in 1)
+  if ((strncmp(romName, "TETRIS SET", 10) == 0) && (sdBuffer[0x14D] == 0x3F)) {
     romType = 0x104;
+  }
+
+  // MMM01 (Mani 4 in 1)
+  if (
+    (strncmp(romName, "BOUKENJIMA2 SET", 15) == 0) && (sdBuffer[0x14D] == 0) ||
+    (strncmp(romName, "BUBBLEBOBBLE SET", 16) == 0) && (sdBuffer[0x14D] == 0xC6) ||
+    (strncmp(romName, "GANBARUGA SET", 13) == 0) && (sdBuffer[0x14D] == 0x90) ||
+    (strncmp(romName, "RTYPE 2 SET", 11) == 0) && (sdBuffer[0x14D] == 0x32)) {
+    romType = 0x0B;
   }
 }
 


### PR DESCRIPTION
Should make reading the ROM data of the following cartridges possible:
- DMG-602 CHN / Mani 4 in 1 - Bubble Bobble + Elevator Action + Chase H.Q. + Sagaia (China) (En)
- DMG-603 CHN / Mani 4 in 1 - Genki Bakuhatsu Gambaruger + Zettai Muteki Raijin-Oh + Zoids Densetsu + Miracle Adventure of Esparks - Ushinawareta Seiseki Perivron (China) (Ja)
- DMG-604 CHN / Mani 4 in 1 - R-Type II + Saigo no Nindou + Ganso!! Yancha Maru + Shisenshou - Match-Mania (China) (Ja)
- DMG-605 CHN / Mani 4 in 1 - Takahashi Meijin no Bouken-jima II + GB Genjin + Bomber Boy + Milon no Meikyuu Kumikyoku (China) (Ja)