### PR TITLE
fix superfx sram size detection

### DIFF
--- a/Cart_Reader/SNES.ino
+++ b/Cart_Reader/SNES.ino
@@ -1102,8 +1102,8 @@ boolean checkcart_SNES() {
   byte sramSizeExp;
   if ((romChips == 19) || (romChips == 20) || (romChips == 21) || (romChips == 26)) {
     // SuperFX
-    if (snesHeader[0x7FDA - headerStart] == 0x33) {
-      sramSizeExp = snesHeader[0x7FBD - headerStart];
+    if (snesHeader[0xFFDA - headerStart] == 0x33) {
+      sramSizeExp = snesHeader[0xFFBD - headerStart];
     } else {
       if (strncmp(romName, "STARFOX2", 8) == 0) {
         sramSizeExp = 6;


### PR DESCRIPTION
The header offsets were wrong so the size wasn't correctly computed and generally ended up defaulting to 32KB. Stunt Race FX, at least, uses 64KB and so only half the save data was being read.