### PR TITLE
More resource usage reduction efforts: factorise N64 JoyBus code, print_Error split

### DIFF
--- a/Cart_Reader/COLV.ino
+++ b/Cart_Reader/COLV.ino
@@ -182,7 +182,7 @@ void readROM_COL() {
 
   // open file on sdcard
   if (!myFile.open(fileName, O_RDWR | O_CREAT))
-    print_Error(create_file_STR, true);
+    print_FatalError(create_file_STR);
 
   // write new folder number back to EEPROM
   foldern++;
@@ -515,7 +515,7 @@ void setCart_COL() {
       }
     }
   } else {
-    print_Error(F("Database file not found"), true);
+    print_FatalError(F("Database file not found"));
   }
 }
 #endif

--- a/Cart_Reader/Cart_Reader.ino
+++ b/Cart_Reader/Cart_Reader.ino
@@ -889,6 +889,12 @@ byte starting_letter() {
 #endif
 }
 
+void print_MissingModule(void) {
+  display_Clear();
+  println_Msg(F("Please enable module"));
+  print_FatalError(F("in Cart_Reader.ino."));
+}
+
 /******************************************
   Main menu optimized for rotary encoder
 *****************************************/
@@ -1067,10 +1073,7 @@ void mainMenu() {
       break;
 
     default:
-      display_Clear();
-      println_Msg(F("Please enable module"));
-      print_Error(F("in Cart_Reader.ino."), true);
-      break;
+      print_MissingModule(); // does not return
   }
 }
 
@@ -1162,6 +1165,9 @@ void mainMenu() {
     case 6:
       resetArduino();
       break;
+
+    default:
+      print_MissingModule(); // does not return
   }
 }
 
@@ -1200,10 +1206,7 @@ void addonMenu() {
       break;
 
     default:
-      display_Clear();
-      println_Msg(F("Please enable module"));
-      print_Error(F("in Cart_Reader.ino."), true);
-      break;
+      print_MissingModule(); // does not return
   }
 }
 
@@ -1259,10 +1262,7 @@ void consoleMenu() {
       break;
 
     default:
-      display_Clear();
-      println_Msg(F("Please enable module"));
-      print_Error(F("in Cart_Reader.ino."), true);
-      break;
+      print_MissingModule(); // does not return
   }
 }
 
@@ -1320,10 +1320,7 @@ void handheldMenu() {
       break;
 
     default:
-      display_Clear();
-      println_Msg(F("Please enable module"));
-      print_Error(F("in Cart_Reader.ino."), true);
-      break;
+      print_MissingModule(); // does not return
   }
 }
 #endif

--- a/Cart_Reader/Cart_Reader.ino
+++ b/Cart_Reader/Cart_Reader.ino
@@ -298,6 +298,9 @@ bool i2c_found;
 #include "FreqCount.h"
 #endif
 
+void print_FatalError(const __FlashStringHelper* errorMessage) __attribute__ ((noreturn));
+void print_FatalError(byte errorMessage) __attribute__ ((noreturn));
+
 /******************************************
   Common Strings
  *****************************************/
@@ -2004,7 +2007,6 @@ void print_Error(byte errorMessage, boolean forceReset) {
   }
 }
 
-void print_FatalError(const __FlashStringHelper* errorMessage) __attribute__ ((noreturn));
 void print_FatalError(const __FlashStringHelper* errorMessage) {
   print_Error(errorMessage, true);
   // Redundant as print_Error already calls it, but makes gcc understand that
@@ -2012,7 +2014,6 @@ void print_FatalError(const __FlashStringHelper* errorMessage) {
   resetArduino();
 }
 
-void print_FatalError(byte errorMessage) __attribute__ ((noreturn));
 void print_FatalError(byte errorMessage){
   print_Error(errorMessage, true);
   // Redundant as print_Error already calls it, but makes gcc understand that

--- a/Cart_Reader/Cart_Reader.ino
+++ b/Cart_Reader/Cart_Reader.ino
@@ -1081,11 +1081,7 @@ static const char modeItem2[] PROGMEM = "SNES/SFC (CLK0+1)";
 static const char modeItem2[] PROGMEM = "Super Nintendo/SFC";
 #endif
 static const char modeItem3[] PROGMEM = "Mega Drive/Genesis";
-#if defined(clockgen_installed)
 static const char modeItem4[] PROGMEM = "N64 (3V EEP CLK1)";
-#else
-static const char modeItem4[] PROGMEM = "Nintendo 64(3V EEP)";
-#endif
 static const char modeItem5[] PROGMEM = "Game Boy";
 static const char modeItem6[] PROGMEM = "About";
 // static const char modeItem7[] PROGMEM = "Reset"; (stored in common strings array)
@@ -2903,15 +2899,6 @@ void wait_btn() {
     // get input button
     int b = checkButton();
 
-#ifdef enable_N64
-#ifndef clockgen_installed
-    // Send some clock pulses to the Eeprom in case it locked up
-    if ((mode == mode_N64_Cart) && ((saveType == 5) || (saveType == 6))) {
-      pulseClock_N64(1);
-    }
-#endif
-#endif
-
     // if the cart readers input button is pressed shortly
     if (b == 1) {
       errorLvl = 0;
@@ -3005,15 +2992,6 @@ void wait_btn() {
     // get input button
     int b = checkButton();
 
-#ifdef enable_N64
-#ifndef clockgen_installed
-    // Send some clock pulses to the Eeprom in case it locked up
-    if ((mode == mode_N64_Cart) && ((saveType == 5) || (saveType == 6))) {
-      pulseClock_N64(1);
-    }
-#endif
-#endif
-
     // if the cart readers input button is pressed shortly
     if (b == 1) {
       errorLvl = 0;
@@ -3044,15 +3022,6 @@ void wait_encoder() {
     // Get rotary encoder
     encoder.tick();
     int newPos = encoder.getPosition();
-
-#ifdef enable_N64
-#ifndef clockgen_installed
-    // Send some clock pulses to the Eeprom in case it locked up
-    if ((mode == mode_N64_Cart) && ((saveType == 5) || (saveType == 6))) {
-      pulseClock_N64(1);
-    }
-#endif
-#endif
 
     if (rotaryPos != newPos) {
       rotaryPos = newPos;

--- a/Cart_Reader/Cart_Reader.ino
+++ b/Cart_Reader/Cart_Reader.ino
@@ -913,6 +913,8 @@ static const char* const modeOptions[] PROGMEM = { modeItem1, modeItem2, modeIte
 void mainMenu() {
   // create menu with title and 15 options to choose from
   unsigned char modeMenu;
+  byte num_answers;
+  byte option_offset;
 
   // Main menu spans across two pages
   currPage = 1;
@@ -921,23 +923,23 @@ void mainMenu() {
 
   while (1) {
     if (currPage == 1) {
-      // Copy menuOptions out of progmem
-      convertPgm(modeOptions + 0, 7);
-      modeMenu = question_box(F("OPEN SOURCE CART READER"), menuOptions, 7, 0);
+      option_offset = 0;
+      num_answers = 7;
     }
     if (currPage == 2) {
-      // Copy menuOptions out of progmem
-      convertPgm(modeOptions + 7, 7);
-      modeMenu = question_box(F("OPEN SOURCE CART READER"), menuOptions, 7, 0);
+      option_offset = 7;
+      num_answers = 7;
     }
     if (currPage == 3) {
-      // Copy menuOptions out of progmem
-      convertPgm(modeOptions + 14, 2);
-      modeMenu = question_box(F("OPEN SOURCE CART READER"), menuOptions, 2, 0);
+      option_offset = 14;
+      num_answers = 2;
     }
+    // Copy menuOptions out of progmem
+    convertPgm(modeOptions + option_offset, num_answers);
+    modeMenu = question_box(F("OPEN SOURCE CART READER"), menuOptions, num_answers, 0);
     if (numPages == 0) {
       // Execute choice
-      modeMenu = (currPage - 1) * 7 + modeMenu;
+      modeMenu += option_offset;
       break;
     }
   }

--- a/Cart_Reader/FLASH.ino
+++ b/Cart_Reader/FLASH.ino
@@ -569,7 +569,7 @@ idtheflash:
     println_Msg(F(""));
     display_Update();
     resetFlash8();
-    print_Error(F("Press Button to reset"), true);
+    print_FatalError(F("Press Button to reset"));
   }
   println_Msg("");
   // Prints string out of the common strings array either with or without newline
@@ -624,7 +624,7 @@ void id_Flash16() {
     flashSize = 8388608;
     flashromType = 2;
   } else {
-    print_Error(F("Unknown flashrom"), true);
+    print_FatalError(F("Unknown flashrom"));
     println_Msg("");
   }
   println_Msg("");
@@ -1054,7 +1054,7 @@ void writeFlash29F032() {
     // Get rom size from file
     fileSize = myFile.fileSize();
     if (fileSize > flashSize)
-      print_Error(file_too_big_STR, true);
+      print_FatalError(file_too_big_STR);
 
     // Set data pins to output
     dataOut();
@@ -1194,7 +1194,7 @@ void writeFlash29F1610() {
     // Get rom size from file
     fileSize = myFile.fileSize();
     if (fileSize > flashSize)
-      print_Error(file_too_big_STR, true);
+      print_FatalError(file_too_big_STR);
 
     // Set data pins to output
     dataOut();
@@ -1248,7 +1248,7 @@ void writeFlash29F1601() {
     // Get rom size from file
     fileSize = myFile.fileSize();
     if (fileSize > flashSize)
-      print_Error(file_too_big_STR, true);
+      print_FatalError(file_too_big_STR);
 
     // Set data pins to output
     dataOut();
@@ -1393,7 +1393,7 @@ void writeFlash29LV640() {
     // Get rom size from file
     fileSize = myFile.fileSize();
     if (fileSize > flashSize)
-      print_Error(file_too_big_STR, true);
+      print_FatalError(file_too_big_STR);
 
     // Set data pins to output
     dataOut();
@@ -1440,7 +1440,7 @@ void writeFlash29GL(unsigned long sectorSize, byte bufferSize) {
     // Get rom size from file
     fileSize = myFile.fileSize();
     if (fileSize > flashSize)
-      print_Error(file_too_big_STR, true);
+      print_FatalError(file_too_big_STR);
 
     // Set data pins to output
     dataOut();
@@ -1507,7 +1507,7 @@ void writeFlash29F800() {
     // Get rom size from file
     fileSize = myFile.fileSize();
     if (fileSize > flashSize)
-      print_Error(file_too_big_STR, true);
+      print_FatalError(file_too_big_STR);
 
     // Set data pins to output
     dataOut();
@@ -1612,7 +1612,7 @@ void writeFlash28FXXX() {
 void writeFlashE28FXXXJ3A() {
   fileSize = myFile.fileSize();
   if (fileSize > flashSize) {
-    print_Error(file_too_big_STR, false);
+    print_Error(file_too_big_STR);
     return;
   }
 
@@ -1663,7 +1663,7 @@ void writeFlashE28FXXXJ3A() {
 void writeFlashLH28F0XX() {
   fileSize = myFile.fileSize();
   if (fileSize > flashSize) {
-    print_Error(file_too_big_STR, false);
+    print_Error(file_too_big_STR);
     return;
   }
 
@@ -1718,7 +1718,7 @@ void blankcheck_Flash() {
     println_Msg(F("Flashrom is empty"));
     display_Update();
   } else {
-    print_Error(F("Error: Not blank"), false);
+    print_Error(F("Error: Not blank"));
   }
 }
 
@@ -1731,7 +1731,7 @@ void verifyFlash() {
     // Get rom size from file
     fileSize = myFile.fileSize();
     if (fileSize > flashSize)
-      print_Error(file_too_big_STR, true);
+      print_FatalError(file_too_big_STR);
 
     blank = 0;
     for (unsigned long currByte = 0; currByte < fileSize; currByte += 512) {
@@ -1750,7 +1750,7 @@ void verifyFlash() {
       print_STR(error_STR, 0);
       print_Msg(blank);
       print_STR(_bytes_STR, 1);
-      print_Error(did_not_verify_STR, false);
+      print_Error(did_not_verify_STR);
     }
     // Close the file:
     myFile.close();
@@ -1782,7 +1782,7 @@ void readFlash() {
 
   // Open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(create_file_STR, true);
+    print_FatalError(create_file_STR);
   }
   for (unsigned long currByte = 0; currByte < flashSize; currByte += 512) {
     for (int c = 0; c < 512; c++) {
@@ -1853,7 +1853,7 @@ void writeFlash16() {
     // Get rom size from file
     fileSize = myFile.fileSize();
     if (fileSize > flashSize)
-      print_Error(file_too_big_STR, true);
+      print_FatalError(file_too_big_STR);
 
     // Set data pins to output
     dataOut16();
@@ -1911,7 +1911,7 @@ void writeFlash16_29F1601() {
     // Get rom size from file
     fileSize = myFile.fileSize();
     if (fileSize > flashSize)
-      print_Error(file_too_big_STR, true);
+      print_FatalError(file_too_big_STR);
 
     // Set data pins to output
     dataOut16();
@@ -2031,7 +2031,7 @@ void blankcheck16() {
     println_Msg(F("Flashrom is empty."));
     display_Update();
   } else {
-    print_Error(F("Error: Not blank"), false);
+    print_Error(F("Error: Not blank"));
   }
 }
 
@@ -2044,7 +2044,7 @@ void verifyFlash16() {
     // Get rom size from file
     fileSize = myFile.fileSize();
     if (fileSize > flashSize) {
-      print_Error(file_too_big_STR, true);
+      print_FatalError(file_too_big_STR);
     }
 
     blank = 0;
@@ -2068,7 +2068,7 @@ void verifyFlash16() {
     } else {
       println_Msg(F("Verification ERROR!"));
       print_Msg(blank);
-      print_Error(F("B did not verify."), false);
+      print_Error(F("B did not verify."));
       display_Update();
     }
     // Close the file:
@@ -2211,7 +2211,7 @@ void writeFlash16_29LV640() {
     // Get rom size from file
     fileSize = myFile.fileSize();
     if (fileSize > flashSize)
-      print_Error(file_too_big_STR, true);
+      print_FatalError(file_too_big_STR);
 
     // Set data pins to output
     dataOut16();
@@ -2374,7 +2374,7 @@ void blankcheck_Eprom() {
     println_Msg(F("Flashrom is empty."));
     display_Update();
   } else {
-    print_Error(F("Error: Not blank"), false);
+    print_Error(F("Error: Not blank"));
   }
 }
 
@@ -2438,7 +2438,7 @@ void write_Eprom() {
     // Get rom size from file
     fileSize = myFile.fileSize();
     if (fileSize > flashSize)
-      print_Error(file_too_big_STR, true);
+      print_FatalError(file_too_big_STR);
 
     // Switch VPP/OE(PH5) to HIGH
     PORTH |= (1 << 5);
@@ -2473,7 +2473,7 @@ void write_Eprom() {
             print_Msg(readWord_Eprom(currWord + c), HEX);
             print_Msg(F(" != 0x"));
             println_Msg(myWord, HEX);
-            print_Error(F("Press button to reset"), true);
+            print_FatalError(F("Press button to reset"));
           }
           n++;
         } while (checkWord != myWord);
@@ -2497,7 +2497,7 @@ void verify_Eprom() {
     // Get rom size from file
     fileSize = myFile.fileSize();
     if (fileSize > flashSize) {
-      print_Error(file_too_big_STR, true);
+      print_FatalError(file_too_big_STR);
     }
 
     blank = 0;
@@ -2521,7 +2521,7 @@ void verify_Eprom() {
     } else {
       println_Msg(F("Verification ERROR!"));
       print_Msg(blank);
-      print_Error(F(" words did not verify."), false);
+      print_Error(F(" words did not verify."));
       display_Update();
     }
     // Close the file:

--- a/Cart_Reader/GB.ino
+++ b/Cart_Reader/GB.ino
@@ -240,7 +240,7 @@ void gbxMenu() {
                     print_STR(error_STR, 0);
                     print_Msg(wrErrors);
                     print_STR(_bytes_STR, 1);
-                    print_Error(did_not_verify_STR, false);
+                    print_Error(did_not_verify_STR);
                   }
                   break;
                 }
@@ -250,7 +250,7 @@ void gbxMenu() {
               println_Msg(F("Error: No save found."));
             }
           } else {
-            print_Error(F("Cart has no Sram"), false);
+            print_Error(F("Cart has no Sram"));
           }
           // Reset
           wait();
@@ -316,7 +316,7 @@ void gbMenu() {
         else
           readSRAM_GB();
       } else {
-        print_Error(F("No save or unsupported type"), false);
+        print_Error(F("No save or unsupported type"));
       }
       println_Msg(F(""));
       break;
@@ -343,11 +343,11 @@ void gbMenu() {
             print_STR(error_STR, 0);
             print_Msg(wrErrors);
             print_STR(_bytes_STR, 1);
-            print_Error(did_not_verify_STR, false);
+            print_Error(did_not_verify_STR);
           }
         }
       } else {
-        print_Error(F("No save or unsupported type"), false);
+        print_Error(F("No save or unsupported type"));
       }
       println_Msg(F(""));
       break;
@@ -547,7 +547,7 @@ void showCartInfo_GB() {
     display_Update();
     wait();
   } else {
-    print_Error(F("GAMEPAK ERROR"), true);
+    print_FatalError(F("GAMEPAK ERROR"));
   }
 }
 
@@ -750,7 +750,7 @@ void getCartInfo_GB() {
     }
 
     if (logoChecksum != 0x1546) {
-    print_Error(F("STARTUP LOGO ERROR"), false);
+    print_Error(F("STARTUP LOGO ERROR"));
     println_Msg(F(""));
     println_Msg(F(""));
     println_Msg(F(""));
@@ -781,7 +781,7 @@ void getCartInfo_GB() {
   }
 
   if (headerChecksum != sdBuffer[0x14D]) {
-    print_Error(F("HEADER CHECKSUM ERROR"), false);
+    print_Error(F("HEADER CHECKSUM ERROR"));
     println_Msg(F(""));
     println_Msg(F(""));
     println_Msg(F(""));
@@ -960,7 +960,7 @@ void readROM_GB() {
 
   //open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(create_file_STR, true);
+    print_FatalError(create_file_STR);
   }
 
   word endAddress = 0x7FFF;
@@ -1109,7 +1109,7 @@ unsigned int calc_checksum_GB(char* fileName) {
   }
   // Else show error
   else {
-    print_Error(F("DUMP ROM 1ST"), false);
+    print_Error(F("DUMP ROM 1ST"));
     return 0;
   }
 }
@@ -1137,7 +1137,7 @@ void compare_checksums_GB() {
   } else {
     print_Msg(F(" != "));
     println_Msg(checksumStr);
-    print_Error(F("Invalid Checksum"), false);
+    print_Error(F("Invalid Checksum"));
   }
   compareCRC("gb.txt", 0, 1, 0);
   display_Update();
@@ -1169,7 +1169,7 @@ void readSRAM_GB() {
 
     //open file on sd card
     if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-      print_Error(sd_error_STR, true);
+      print_FatalError(sd_error_STR);
     }
 
     // MBC2 Fix
@@ -1207,7 +1207,7 @@ void readSRAM_GB() {
     println_Msg(F("/"));
     display_Update();
   } else {
-    print_Error(F("Cart has no SRAM"), false);
+    print_Error(F("Cart has no SRAM"));
   }
 }
 
@@ -1250,10 +1250,10 @@ void writeSRAM_GB() {
       display_Update();
 
     } else {
-      print_Error(F("File doesnt exist"), false);
+      print_Error(F("File doesnt exist"));
     }
   } else {
-    print_Error(F("Cart has no SRAM"), false);
+    print_Error(F("Cart has no SRAM"));
   }
 }
 
@@ -1300,7 +1300,7 @@ unsigned long verifySRAM_GB() {
     myFile.close();
     return writeErrors;
   } else {
-    print_Error(open_file_STR, true);
+    print_FatalError(open_file_STR);
     return 1;
   }
 }
@@ -1329,7 +1329,7 @@ void readSRAMFLASH_MBC6_GB() {
 
   //open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   //Initialize progress bar
@@ -1476,7 +1476,7 @@ void writeSRAMFLASH_MBC6_GB() {
             writeByte_GB(0x3800, 0x00);
             myFile.close();
             display_Clear();
-            print_Error(F("Error erasing FLASH sector."), true);
+            print_FatalError(F("Error erasing FLASH sector."));
           }
         }
       } else {
@@ -1515,7 +1515,7 @@ void writeSRAMFLASH_MBC6_GB() {
             writeByte_GB(0x3800, 0x00);
             myFile.close();
             display_Clear();
-            print_Error(F("Error writing to FLASH."), true);
+            print_FatalError(F("Error writing to FLASH."));
           }
         }
         writeByte_GB(romAddress - 1, 0xF0);
@@ -1536,7 +1536,7 @@ void writeSRAMFLASH_MBC6_GB() {
     println_Msg(F("Save writing finished"));
     display_Update();
   } else {
-    print_Error(F("File doesnt exist"), false);
+    print_Error(F("File doesnt exist"));
   }
 }
 
@@ -1649,7 +1649,7 @@ void writeFlash29F_GB(byte MBC, boolean flashErase) {
       sprintf(flashid_str, "%04X", flashid);
       println_Msg(flashid_str);
       display_Update();
-      print_Error(F("Unknown flashrom"), true);
+      print_FatalError(F("Unknown flashrom"));
     }
 
     // Reset flash
@@ -1696,7 +1696,7 @@ void writeFlash29F_GB(byte MBC, boolean flashErase) {
           for (int j = 0; j < 512; j++) {
             if (sdBuffer[j] != 0xFF) {
               println_Msg(F("Not empty"));
-              print_Error(F("Erase failed"), true);
+              print_FatalError(F("Erase failed"));
             }
           }
         }
@@ -1852,7 +1852,7 @@ void writeFlash29F_GB(byte MBC, boolean flashErase) {
       println_Msg(F("Error"));
       print_Msg(writeErrors);
       print_STR(_bytes_STR, 1);
-      print_Error(did_not_verify_STR, true);
+      print_FatalError(did_not_verify_STR);
     }
   } else {
     print_STR(open_file_STR, 1);
@@ -2095,7 +2095,7 @@ bool writeCFI_GB() {
         for (int j = 0; j < 512; j++) {
           if (sdBuffer[j] != 0xFF) {
             println_Msg(F("Not empty"));
-            print_Error(F("Erase failed"), true);
+            print_FatalError(F("Erase failed"));
           }
         }
       }
@@ -2212,7 +2212,7 @@ bool writeCFI_GB() {
       print_STR(error_STR, 0);
       print_Msg(writeErrors);
       print_STR(_bytes_STR, 1);
-      print_Error(did_not_verify_STR, false);
+      print_Error(did_not_verify_STR);
     }
   } else {
     print_STR(open_file_STR, 1);

--- a/Cart_Reader/GBA.ino
+++ b/Cart_Reader/GBA.ino
@@ -161,7 +161,7 @@ void gbaMenu() {
             printFlashTypeAndWait(F("Panasonic MN63F805MNP"));
           } else {
             printFlashTypeAndWait(F("Unknown"));
-            //print_Error(F(""), true);
+            //print_FatalError(F(""));
           }
 
           if (flashid == 0x1F3D) {  // Atmel
@@ -187,7 +187,7 @@ void gbaMenu() {
             printFlashTypeAndWait(F("SANYO LE26FV10N1TS"));
           } else {
             printFlashTypeAndWait(F("Unknown"));
-            //print_Error(F(""), true);
+            //print_FatalError(F(""));
           }
 
           eraseFLASH_GBA();
@@ -593,7 +593,7 @@ void getCartInfo_GBA() {
 
   if (logoChecksum != 0x4B1B) {
     display_Clear();
-    print_Error(F("CARTRIDGE ERROR"), false);
+    print_Error(F("CARTRIDGE ERROR"));
     strcpy(romName, "ERROR");
     println_Msg(F(""));
     println_Msg(F(""));
@@ -755,7 +755,7 @@ void getCartInfo_GBA() {
       dont_log = false;
 #endif
     } else {
-      print_Error(F("GBA.txt missing"), true);
+      print_FatalError(F("GBA.txt missing"));
     }
 
     // Get name
@@ -780,7 +780,7 @@ void getCartInfo_GBA() {
       // Turn into string
       sprintf(calcChecksumStr, "%02X", calcChecksum);
       println_Msg(calcChecksumStr);
-      print_Error(F("Checksum Error"), false);
+      print_Error(F("Checksum Error"));
       println_Msg(F(""));
       // Prints string out of the common strings array either with or without newline
       print_STR(press_button_STR, 1);
@@ -865,7 +865,7 @@ void readROM_GBA() {
 
   //open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(create_file_STR, true);
+    print_FatalError(create_file_STR);
   }
 
   //Initialize progress bar
@@ -927,13 +927,13 @@ boolean compare_checksum_GBA() {
     } else {
       print_Msg(F(" != "));
       println_Msg(checksumStr);
-      print_Error(F("Invalid Checksum"), false);
+      print_Error(F("Invalid Checksum"));
       return 0;
     }
   }
   // Else show error
   else {
-    print_Error(F("Failed to open rom"), false);
+    print_Error(F("Failed to open rom"));
     return 0;
   }
 }
@@ -966,7 +966,7 @@ void readSRAM_GBA(boolean browseFile, unsigned long sramSize, uint32_t pos) {
 
   //open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   // Seek to a new position in the file
@@ -1022,7 +1022,7 @@ void writeSRAM_GBA(boolean browseFile, unsigned long sramSize, uint32_t pos) {
     display_Update();
 
   } else {
-    print_Error(F("File doesnt exist"), false);
+    print_Error(F("File doesnt exist"));
   }
 }
 
@@ -1057,12 +1057,12 @@ unsigned long verifySRAM_GBA(unsigned long sramSize, uint32_t pos) {
       print_STR(error_STR, 0);
       print_Msg(writeErrors);
       print_STR(_bytes_STR, 1);
-      print_Error(did_not_verify_STR, false);
+      print_Error(did_not_verify_STR);
     }
 
     return writeErrors;
   } else {
-    print_Error(F("Can't open file"), false);
+    print_Error(F("Can't open file"));
     return 1;
   }
 }
@@ -1106,7 +1106,7 @@ void readFRAM_GBA(unsigned long framSize) {
 
   //open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
   for (unsigned long currAddress = 0; currAddress < framSize; currAddress += 512) {
     for (int c = 0; c < 512; c++) {
@@ -1209,7 +1209,7 @@ void writeFRAM_GBA(boolean browseFile, unsigned long framSize) {
     display_Update();
 
   } else {
-    print_Error(F("File doesnt exist"), false);
+    print_Error(F("File doesnt exist"));
   }
 }
 
@@ -1270,7 +1270,7 @@ unsigned long verifyFRAM_GBA(unsigned long framSize) {
     myFile.close();
     return writeErrors;
   } else {
-    print_Error(F("Can't open file"), false);
+    print_Error(F("Can't open file"));
     return 1;
   }
 }
@@ -1461,7 +1461,7 @@ boolean blankcheckFLASH_GBA(unsigned long flashSize) {
     // Check buffer
     for (unsigned long currByte = 0; currByte < 512; currByte++) {
       if (sdBuffer[currByte] != 0xFF) {
-        print_Error(F("Erase failed"), false);
+        print_Error(F("Erase failed"));
         currByte = 512;
         currAddress = flashSize;
         blank = 0;
@@ -1539,7 +1539,7 @@ void readFLASH_GBA(boolean browseFile, unsigned long flashSize, uint32_t pos) {
 
   //open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   // Seek to a new position in the file
@@ -1657,7 +1657,7 @@ void writeFLASH_GBA(boolean browseFile, unsigned long flashSize, uint32_t pos, b
 
   } else {
     println_Msg(F("Error"));
-    print_Error(F("File doesnt exist"), false);
+    print_Error(F("File doesnt exist"));
   }
 }
 
@@ -1684,7 +1684,7 @@ unsigned long verifyFLASH_GBA(unsigned long flashSize, uint32_t pos) {
 
   //open file on sd card
   if (!myFile.open(filePath, O_READ)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   // Seek to a new position in the file
@@ -1710,7 +1710,7 @@ unsigned long verifyFLASH_GBA(unsigned long flashSize, uint32_t pos) {
     println_Msg(F("OK"));
   } else {
     print_Msg(wrError);
-    print_Error(F(" Errors"), false);
+    print_Error(F(" Errors"));
   }
 
   return wrError;
@@ -1753,7 +1753,7 @@ void writeEeprom_GBA(word eepSize) {
     display_Update();
   } else {
     println_Msg(F("Error"));
-    print_Error(F("File doesnt exist"), false);
+    print_Error(F("File doesnt exist"));
   }
 }
 
@@ -1782,7 +1782,7 @@ void readEeprom_GBA(word eepSize) {
 
   //open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   // Each block contains 8 Bytes, so for a 8KB eeprom 1024 blocks need to be read
@@ -2024,7 +2024,7 @@ unsigned long verifyEEP_GBA(word eepSize) {
 
   //open file on sd card
   if (!myFile.open(filePath, O_READ)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   // Fill sd Buffer
@@ -2050,7 +2050,7 @@ unsigned long verifyEEP_GBA(word eepSize) {
     print_STR(error_STR, 0);
     print_Msg(wrError);
     print_STR(_bytes_STR, 1);
-    print_Error(did_not_verify_STR, false);
+    print_Error(did_not_verify_STR);
   }
 
   return wrError;
@@ -2134,7 +2134,7 @@ void idFlashrom_GBA() {
       print_Msg(F("Flash ID: "));
       println_Msg(flashid_str);
       println_Msg(F(""));
-      print_Error(F("Check voltage"), true);
+      print_FatalError(F("Check voltage"));
     }
   }
 }
@@ -2532,7 +2532,7 @@ boolean verifyFlashrom_GBA() {
       return 0;
     }
   } else {
-    print_Error(open_file_STR, true);
+    print_FatalError(open_file_STR);
     return 9999;
   }
 }
@@ -2561,7 +2561,7 @@ void flashRepro_GBA() {
       } else {
         print_Msg(F("romType: 0x"));
         println_Msg(romType, HEX);
-        print_Error(F("Unknown manufacturer"), true);
+        print_FatalError(F("Unknown manufacturer"));
       }
     }
     // Intel 4000L0YBQ0
@@ -2614,7 +2614,7 @@ void flashRepro_GBA() {
         resetIntel_GBA(0x200000);
       } else if (flashid == 0x227E) {
         //if (sectorCheckMX29GL128E_GBA()) {
-        //print_Error(F("Sector Protected"), true);
+        //print_FatalError(F("Sector Protected"));
         //}
         //else {
         println_Msg(F("Erasing..."));
@@ -2680,16 +2680,16 @@ void flashRepro_GBA() {
         println_Msg(F("OK"));
         display_Update();
       } else {
-        print_Error(F("ERROR"), true);
+        print_FatalError(F("ERROR"));
       }
       /* Skipped blankcheck
         }
         else {
-        print_Error(F("failed"), true);
+        print_FatalError(F("failed"));
         }
       */
     } else {
-      print_Error(open_file_STR, true);
+      print_FatalError(open_file_STR);
     }
   } else {
     println_Msg(F("Error"));
@@ -2698,7 +2698,7 @@ void flashRepro_GBA() {
     print_Msg(F("Flash ID: "));
     println_Msg(flashid_str);
     println_Msg(F(""));
-    print_Error(F("Check voltage"), true);
+    print_FatalError(F("Check voltage"));
   }
 }
 

--- a/Cart_Reader/GBM.ino
+++ b/Cart_Reader/GBM.ino
@@ -165,7 +165,7 @@ void gbmMenu() {
         println_Msg(F("OK"));
         display_Update();
       } else {
-        print_Error(F("Erasing failed"), false);
+        print_Error(F("Erasing failed"));
         break;
       }
 
@@ -235,7 +235,7 @@ void setup_GBM() {
     timeout++;
     if (timeout > 10) {
       println_Msg(F("Error: Time Out"));
-      print_Error(F("Please power cycle"), true);
+      print_FatalError(F("Please power cycle"));
     }
   }
 }
@@ -337,7 +337,7 @@ void readROM_GBM(word numBanks) {
 
   // Open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(create_file_STR, true);
+    print_FatalError(create_file_STR);
   } else {
     // Read rom
     word currAddress = 0;
@@ -439,7 +439,7 @@ void send_GBM(byte myCommand) {
       break;
 
     default:
-      print_Error(F("Unknown Command"), true);
+      print_FatalError(F("Unknown Command"));
       break;
   }
 }
@@ -459,7 +459,7 @@ void send_GBM(byte myCommand, word myAddress, byte myData) {
       break;
 
     default:
-      print_Error(F("Unknown Command"), true);
+      print_FatalError(F("Unknown Command"));
       break;
   }
 }
@@ -508,7 +508,7 @@ boolean readFlashID_GBM() {
   } else {
     print_Msg(F("Flash ID: "));
     println_Msg(flashid_str);
-    print_Error(F("Unknown Flash ID"), true);
+    print_FatalError(F("Unknown Flash ID"));
     resetFlash_GBM();
     return 0;
   }
@@ -592,7 +592,7 @@ void writeFlash_GBM() {
     // Get rom size from file
     fileSize = myFile.fileSize();
     if ((fileSize / 0x4000) > 64) {
-      print_Error(F("File is too big."), true);
+      print_FatalError(F("File is too big."));
     }
 
     // Enable access to ports 0120h
@@ -685,7 +685,7 @@ void writeFlash_GBM() {
     myFile.close();
     print_STR(done_STR, 1);
   } else {
-    print_Error(F("Can't open file"), false);
+    print_Error(F("Can't open file"));
   }
 }
 
@@ -722,7 +722,7 @@ void readMapping_GBM() {
 
   // Open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(create_file_STR, true);
+    print_FatalError(create_file_STR);
   } else {
     for (byte currByte = 0; currByte < 128; currByte++) {
       sdBuffer[currByte] = readByte_GBM(currByte);
@@ -821,7 +821,7 @@ void writeMapping_GBM() {
   if (myFile.open(filePath, O_READ)) {
     // Get map file size and check if it exceeds 128KByte
     if (myFile.fileSize() > 0x80) {
-      print_Error(F("File is too big."), true);
+      print_FatalError(F("File is too big."));
     }
 
     // Enable access to ports 0120h
@@ -899,7 +899,7 @@ void writeMapping_GBM() {
     myFile.close();
     print_STR(done_STR, 1);
   } else {
-    print_Error(F("Can't open file"), false);
+    print_Error(F("Can't open file"));
   }
 }
 

--- a/Cart_Reader/GBS.ino
+++ b/Cart_Reader/GBS.ino
@@ -72,7 +72,7 @@ boolean compare_checksum_GBS() {
   } else {
     print_Msg(F("Result: "));
     println_Msg(calcsumStr);
-    print_Error(F("Checksum Error"), false);
+    print_Error(F("Checksum Error"));
     return 0;
   }
 }
@@ -206,7 +206,7 @@ void gbSmartGameOptions() {
           print_STR(error_STR, 0);
           print_Msg(wrErrors);
           println_Msg(F(" bytes"));
-          print_Error(did_not_verify_STR, false);
+          print_Error(did_not_verify_STR);
         }
         break;
       }
@@ -400,7 +400,7 @@ void gbSmartReadFlash() {
   display_Update();
 
   if (!myFile.open(fileName, O_RDWR | O_CREAT))
-    print_Error(create_file_STR, true);
+    print_FatalError(create_file_STR);
 
   // reset flash to read array state
   for (uint16_t i = 0x00; i < gbSmartBanks; i += gbSmartBanksPerFlashChip)
@@ -456,7 +456,7 @@ void gbSmartWriteFlash() {
     display_Update();
 
     if (!gbSmartBlankCheckingFlash(bank))
-      print_Error(F("Could not erase flash"), true);
+      print_FatalError(F("Could not erase flash"));
 
     println_Msg(F("Passed"));
     display_Update();
@@ -479,13 +479,13 @@ void gbSmartWriteFlash() {
     print_STR(error_STR, 0);
     print_Msg(writeErrors);
     print_STR(_bytes_STR, 1);
-    print_Error(did_not_verify_STR, true);
+    print_FatalError(did_not_verify_STR);
   }
 }
 
 void gbSmartWriteFlash(uint32_t start_bank) {
   if (!myFile.open(filePath, O_READ))
-    print_Error(open_file_STR, true);
+    print_FatalError(open_file_STR);
 
   // switch to flash base bank
   gbSmartRemapStartBank(start_bank, gbSmartFlashSizeGB, gbSmartSramSizeGB);
@@ -546,7 +546,7 @@ uint32_t gbSmartVerifyFlash() {
 
   if (!myFile.open(filePath, O_READ)) {
     verified = 0xffffffff;
-    print_Error(F("Can't open file on SD"), false);
+    print_Error(F("Can't open file on SD"));
   } else {
     // remaps mmc to full access
     gbSmartRemapStartBank(0x00, gbSmartRomSizeGB, gbSmartSramSizeGB);

--- a/Cart_Reader/INTV.ino
+++ b/Cart_Reader/INTV.ino
@@ -323,7 +323,7 @@ void readROM_INTV() {
 
   // open file on sdcard
   if (!myFile.open(fileName, O_RDWR | O_CREAT))
-    print_Error(create_file_STR, true);
+    print_FatalError(create_file_STR);
 
   // write new folder number back to EEPROM
   foldern++;
@@ -938,7 +938,7 @@ void setCart_INTV() {
       }
     }
   } else {
-    print_Error(F("Database file not found"), true);
+    print_FatalError(F("Database file not found"));
   }
 }
 #endif

--- a/Cart_Reader/MD.ino
+++ b/Cart_Reader/MD.ino
@@ -255,7 +255,7 @@ void mdMenu() {
         println_Msg(F("MX29F1610 detected"));
         flashSize = 2097152;
       } else {
-        print_Error(F("Error: Unknown flashrom"), true);
+        print_FatalError(F("Error: Unknown flashrom"));
       }
       display_Update();
 
@@ -307,7 +307,7 @@ void mdCartMenu() {
           readROM_MD();
         }
       } else {
-        print_Error(F("Cart has no ROM"), false);
+        print_Error(F("Cart has no ROM"));
       }
 #ifdef global_log
       save_log();
@@ -326,7 +326,7 @@ void mdCartMenu() {
         readSram_MD();
         enableSram_MD(0);
       } else {
-        print_Error(F("Cart has no Sram"), false);
+        print_Error(F("Cart has no Sram"));
       }
       break;
 
@@ -350,10 +350,10 @@ void mdCartMenu() {
           print_STR(error_STR, 0);
           print_Msg(writeErrors);
           print_STR(_bytes_STR, 1);
-          print_Error(did_not_verify_STR, false);
+          print_Error(did_not_verify_STR);
         }
       } else {
-        print_Error(F("Cart has no Sram"), false);
+        print_Error(F("Cart has no Sram"));
       }
       break;
 
@@ -362,7 +362,7 @@ void mdCartMenu() {
       if (saveType == 4)
         readEEP_MD();
       else {
-        print_Error(F("Cart has no EEPROM"), false);
+        print_Error(F("Cart has no EEPROM"));
       }
       break;
 
@@ -374,7 +374,7 @@ void mdCartMenu() {
         display_Clear();
         writeEEP_MD();
       } else {
-        print_Error(F("Cart has no EEPROM"), false);
+        print_Error(F("Cart has no EEPROM"));
       }
       break;
 
@@ -417,7 +417,7 @@ void segaCDMenu() {
       if (bramSize > 0)
         readBram_MD();
       else {
-        print_Error(F("Not CD Backup RAM Cart"), false);
+        print_Error(F("Not CD Backup RAM Cart"));
       }
       break;
 
@@ -429,7 +429,7 @@ void segaCDMenu() {
         display_Clear();
         writeBram_MD();
       } else {
-        print_Error(F("Not CD Backup RAM Cart"), false);
+        print_Error(F("Not CD Backup RAM Cart"));
       }
       break;
 
@@ -882,7 +882,7 @@ void getCartInfo_MD() {
           print_Msg(("sramEnd: "));
           print_Msg_PaddedHex32(sramEnd);
           println_Msg(F(""));
-          print_Error(F("Unknown Sram Base"), true);
+          print_FatalError(F("Unknown Sram Base"));
         }
       } else if (sramType == 0xE020) {  // SRAM BOTH BYTES
         // Get sram start and end
@@ -907,7 +907,7 @@ void getCartInfo_MD() {
           print_Msg(("sramEnd: "));
           print_Msg_PaddedHex32(sramEnd);
           println_Msg(F(""));
-          print_Error(F("Unknown Sram Base"), true);
+          print_FatalError(F("Unknown Sram Base"));
         }
       }
     } else {
@@ -1164,7 +1164,7 @@ void readROM_MD() {
 
   // Open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   byte buffer[1024] = { 0 };
@@ -1371,7 +1371,7 @@ void readROM_MD() {
     char calcsumStr[5];
     sprintf(calcsumStr, "%04X", calcCKS);
     println_Msg(calcsumStr);
-    print_Error(F(""), false);
+    print_Error(F(""));
     display_Update();
   }
 
@@ -1392,7 +1392,7 @@ void readROM_MD() {
       char calcsumStr[5];
       sprintf(calcsumStr, "%04X", calcCKSLockon);
       println_Msg(calcsumStr);
-      print_Error(F(""), false);
+      print_Error(F(""));
       display_Update();
     }
   }
@@ -1405,7 +1405,7 @@ void readROM_MD() {
       char calcsumStr[5];
       sprintf(calcsumStr, "%04X", calcCKSSonic2);
       println_Msg(calcsumStr);
-      print_Error(F(""), false);
+      print_Error(F(""));
       display_Update();
     }
   }
@@ -1483,14 +1483,14 @@ void writeSram_MD() {
         writeWord_MD(currByte, data);
       }
     } else
-      print_Error(F("Unknown save type"), false);
+      print_Error(F("Unknown save type"));
 
     // Close the file:
     myFile.close();
     print_STR(done_STR, 1);
     display_Update();
   } else {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
   dataIn_MD();
 }
@@ -1515,7 +1515,7 @@ void readSram_MD() {
 
   // Open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   for (unsigned long currBuffer = sramBase; currBuffer < sramBase + sramSize; currBuffer += 256) {
@@ -1609,7 +1609,7 @@ unsigned long verifySram_MD() {
     // Close the file:
     myFile.close();
   } else {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
   // Return 0 if verified ok, or number of errors
   return writeErrors;
@@ -1645,7 +1645,7 @@ void write29F1610_MD() {
     // Get rom size from file
     fileSize = myFile.fileSize();
     if (fileSize > flashSize) {
-      print_Error(file_too_big_STR, true);
+      print_FatalError(file_too_big_STR);
     }
     // Set data pins to output
     dataOut_MD();
@@ -1754,7 +1754,7 @@ void blankcheck_MD() {
     }
   }
   if (!blank) {
-    print_Error(F("Error: Not blank"), false);
+    print_Error(F("Error: Not blank"));
   }
 }
 
@@ -1764,7 +1764,7 @@ void verifyFlash_MD() {
     // Get rom size from file
     fileSize = myFile.fileSize();
     if (fileSize > flashSize) {
-      print_Error(file_too_big_STR, true);
+      print_FatalError(file_too_big_STR);
     }
 
     blank = 0;
@@ -1792,7 +1792,7 @@ void verifyFlash_MD() {
       print_STR(error_STR, 0);
       print_Msg(blank);
       print_STR(_bytes_STR, 1);
-      print_Error(did_not_verify_STR, false);
+      print_Error(did_not_verify_STR);
     }
     // Close the file:
     myFile.close();
@@ -2382,7 +2382,7 @@ void readEEP_MD() {
 
   // Open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
   if (eepSize > 0x100) {  // 24C04+
     for (word currByte = 0; currByte < eepSize; currByte += 256) {
@@ -2451,7 +2451,7 @@ void writeEEP_MD() {
     print_STR(done_STR, 1);
     display_Update();
   } else {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
   dataIn_MD();
 }
@@ -2481,7 +2481,7 @@ void readBram_MD() {
 
   // Open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   for (unsigned long currByte = 0; currByte < bramSize; currByte += 512) {
@@ -2530,7 +2530,7 @@ void writeBram_MD() {
     print_STR(done_STR, 1);
     display_Update();
   } else {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
   dataIn_MD();
 }
@@ -2579,7 +2579,7 @@ void readRealtec_MD() {
 
   // Open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   // Realtec Registers

--- a/Cart_Reader/N64.ino
+++ b/Cart_Reader/N64.ino
@@ -50,6 +50,9 @@ String CRC1 = "";
 String CRC2 = "";
 #endif
 
+static const char N64_EEP_FILENAME_FMT[] PROGMEM = "%s.eep";
+static const char N64_SAVE_DIRNAME_FMT[] PROGMEM = "N64/SAVE/%s/%d";
+
 /******************************************
   Menu
 *****************************************/
@@ -2687,12 +2690,11 @@ void writeEeprom() {
 void readEeprom() {
   if ((saveType == 5) || (saveType == 6)) {
     // Get name, add extension and convert to char array for sd lib
-    strcpy(fileName, romName);
-    strcat(fileName, ".eep");
+    snprintf_P(fileName, sizeof(fileName), N64_EEP_FILENAME_FMT, romName);
 
     // create a new folder for the save file
     EEPROM_readAnything(0, foldern);
-    sprintf(folder, "N64/SAVE/%s/%d", romName, foldern);
+    snprintf_P(folder, sizeof(folder), N64_SAVE_DIRNAME_FMT, romName, foldern);
     sd.mkdir(folder, true);
     sd.chdir(folder);
 

--- a/Cart_Reader/N64.ino
+++ b/Cart_Reader/N64.ino
@@ -258,7 +258,7 @@ void n64CartMenu() {
         display_Update();
         readEeprom();
       } else {
-        print_Error(F("Savetype Error"), false);
+        print_Error(F("Savetype Error"));
       }
       println_Msg(F(""));
       // Prints string out of the common strings array either with or without newline
@@ -284,7 +284,7 @@ void n64CartMenu() {
           print_STR(error_STR, 0);
           print_Msg(writeErrors);
           print_STR(_bytes_STR, 1);
-          print_Error(did_not_verify_STR, false);
+          print_Error(did_not_verify_STR);
         }
       } else if (saveType == 4) {
         // Launch file browser
@@ -303,7 +303,7 @@ void n64CartMenu() {
           print_STR(error_STR, 0);
           print_Msg(writeErrors);
           print_STR(_bytes_STR, 1);
-          print_Error(did_not_verify_STR, false);
+          print_Error(did_not_verify_STR);
         }
       } else if ((saveType == 5) || (saveType == 6)) {
         // Launch file browser
@@ -320,11 +320,11 @@ void n64CartMenu() {
           print_STR(error_STR, 0);
           print_Msg(writeErrors);
           print_STR(_bytes_STR, 1);
-          print_Error(did_not_verify_STR, false);
+          print_Error(did_not_verify_STR);
         }
       } else {
         display_Clear();
-        print_Error(F("Save Type Error"), false);
+        print_Error(F("Save Type Error"));
       }
       // Prints string out of the common strings array either with or without newline
       print_STR(press_button_STR, 1);
@@ -413,7 +413,7 @@ void setup_N64_Cart() {
 
   if (!i2c_found) {
     display_Clear();
-    print_Error(F("Clock Generator not found"), true);
+    print_FatalError(F("Clock Generator not found"));
   }
 
   // Set Eeprom clock to 2Mhz
@@ -1512,7 +1512,7 @@ void checkController() {
 
   // Check if line is HIGH
   if (!N64_QUERY)
-    print_Error(F("Data line LOW"), true);
+    print_FatalError(F("Data line LOW"));
 
   // don't want interrupts getting in the way
   noInterrupts();
@@ -1522,9 +1522,9 @@ void checkController() {
   interrupts();
 
   if (response[0] != 0x05)
-    print_Error(F("Controller not found"), true);
+    print_FatalError(F("Controller not found"));
   if (response[2] != 0x01)
-    print_Error(F("Controller Pak not found"), true);
+    print_FatalError(F("Controller Pak not found"));
 }
 
 // read 32bytes from controller pak and calculate CRC
@@ -1548,7 +1548,7 @@ byte readBlock(byte *output, word myAddress) {
     myFile.close();
     println_Msg(F("Controller Pak was"));
     println_Msg(F("not dumped due to a"));
-    print_Error(F("read timeout"), true);
+    print_FatalError(F("read timeout"));
   }
 
   // Compare with computed CRC
@@ -1558,7 +1558,7 @@ byte readBlock(byte *output, word myAddress) {
     myFile.close();
     println_Msg(F("Controller Pak was"));
     println_Msg(F("not dumped due to a"));
-    print_Error(F("protocol CRC error"), true);
+    print_FatalError(F("protocol CRC error"));
   }
 
   return response_crc;
@@ -1587,12 +1587,12 @@ void readMPK() {
   strcat(filePath, ".crc");
   FsFile crcFile;
   if (!crcFile.open(filePath, O_RDWR | O_CREAT)) {
-    print_Error(open_file_STR, true);
+    print_FatalError(open_file_STR);
   }
 
   //open mpk file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(open_file_STR, true);
+    print_FatalError(open_file_STR);
   }
 
   print_Msg(F("Saving N64/MPK/"));
@@ -1645,12 +1645,12 @@ void verifyCRC() {
   //open CRC file on sd card
   FsFile crcFile;
   if (!crcFile.open(filePath, O_READ)) {
-    print_Error(open_file_STR, true);
+    print_FatalError(open_file_STR);
   }
 
   //open MPK file on sd card
   if (!myFile.open(fileName, O_READ)) {
-    print_Error(open_file_STR, true);
+    print_FatalError(open_file_STR);
   }
 
   //Initialize progress bar
@@ -1688,7 +1688,7 @@ void verifyCRC() {
     print_STR(error_STR, 0);
     print_Msg(writeErrors);
     println_Msg(F(" blocks "));
-    print_Error(did_not_verify_STR, false);
+    print_Error(did_not_verify_STR);
   }
 }
 
@@ -1714,7 +1714,7 @@ void validateMPK() {
 
   //open file on sd card
   if (!mpk_file.open(fileName, O_READ)) {
-    print_Error(open_file_STR, true);
+    print_FatalError(open_file_STR);
   }
 
   // Read first 256 byte which contains the header including checksum and reverse checksum and three copies of it
@@ -1820,7 +1820,7 @@ void writeMPK() {
     // Close the file:
     myFile.close();
   } else {
-    print_Error(open_file_STR, true);
+    print_FatalError(open_file_STR);
   }
 }
 
@@ -1834,7 +1834,7 @@ void verifyMPK() {
 
   //open file on sd card
   if (!myFile.open(filePath, O_READ)) {
-    print_Error(open_file_STR, true);
+    print_FatalError(open_file_STR);
   }
 
   //Initialize progress bar
@@ -1879,7 +1879,7 @@ void verifyMPK() {
     print_STR(error_STR, 0);
     print_Msg(writeErrors);
     print_STR(_bytes_STR, 1);
-    print_Error(did_not_verify_STR, false);
+    print_Error(did_not_verify_STR);
   }
 }
 
@@ -1946,7 +1946,7 @@ void printCartInfo_N64() {
     display_Update();
 
     strcpy(romName, "GPERROR");
-    print_Error(F("Cartridge unknown"), false);
+    print_Error(F("Cartridge unknown"));
     println_Msg("");
     // Prints string out of the common strings array either with or without newline
     print_STR(press_button_STR, 1);
@@ -2045,7 +2045,7 @@ void printCartInfo_N64() {
     return result;
   }
   else {
-    print_Error(F("n64.txt missing"), true);
+    print_FatalError(F("n64.txt missing"));
   }
   }*/
 
@@ -2107,7 +2107,7 @@ void getCartInfo_N64() {
     // Close the file:
     myFile.close();
   } else {
-    print_Error(F("n64.txt missing"), true);
+    print_FatalError(F("n64.txt missing"));
   }
 }
 
@@ -2204,10 +2204,10 @@ void writeEeprom() {
       display_Update();
       delay(600);
     } else {
-      print_Error(sd_error_STR, true);
+      print_FatalError(sd_error_STR);
     }
   } else {
-    print_Error(F("Savetype Error"), true);
+    print_FatalError(F("Savetype Error"));
   }
 }
 
@@ -2251,7 +2251,7 @@ void readEeprom() {
 
     // Open file on sd card
     if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-      print_Error(create_file_STR, true);
+      print_FatalError(create_file_STR);
     }
 
     for (int i = 0; i < eepPages; i += sizeof(sdBuffer) / 8) {
@@ -2268,7 +2268,7 @@ void readEeprom() {
     println_Msg(F("/"));
     display_Update();
   } else {
-    print_Error(F("Savetype Error"), true);
+    print_FatalError(F("Savetype Error"));
   }
 }
 
@@ -2300,12 +2300,12 @@ unsigned long verifyEeprom() {
     } else {
       // SD Error
       writeErrors = 999999;
-      print_Error(sd_error_STR, true);
+      print_FatalError(sd_error_STR);
     }
     // Return 0 if verified ok, or number of errors
     return writeErrors;
   } else {
-    print_Error(F("Savetype Error"), true);
+    print_FatalError(F("Savetype Error"));
     return 1;
   }
 }
@@ -2345,11 +2345,11 @@ void writeSram(unsigned long sramSize) {
       print_STR(done_STR, 1);
       display_Update();
     } else {
-      print_Error(sd_error_STR, true);
+      print_FatalError(sd_error_STR);
     }
 
   } else {
-    print_Error(F("Savetype Error"), true);
+    print_FatalError(F("Savetype Error"));
   }
 }
 
@@ -2370,7 +2370,7 @@ void readSram(unsigned long sramSize, byte flashramType) {
   } else if (saveType == 1) {
     strcat(fileName, ".sra");
   } else {
-    print_Error(F("Savetype Error"), true);
+    print_FatalError(F("Savetype Error"));
   }
 
   // create a new folder for the save file
@@ -2385,7 +2385,7 @@ void readSram(unsigned long sramSize, byte flashramType) {
 
   // Open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   for (unsigned long currByte = sramBase; currByte < (sramBase + (sramSize / flashramType)); currByte += offset) {
@@ -2448,7 +2448,7 @@ unsigned long verifySram(unsigned long sramSize, byte flashramType) {
     // Close the file:
     myFile.close();
   } else {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
   // Return 0 if verified ok, or number of errors
   return writeErrors;
@@ -2554,10 +2554,10 @@ void writeFram(byte flashramType) {
       // Close the file:
       myFile.close();
     } else {
-      print_Error(sd_error_STR, true);
+      print_FatalError(sd_error_STR);
     }
   } else {
-    print_Error(F("Savetype Error"), true);
+    print_FatalError(F("Savetype Error"));
   }
 }
 
@@ -2585,7 +2585,7 @@ void eraseFram() {
       }
     }
   } else {
-    print_Error(F("Savetype Error"), true);
+    print_FatalError(F("Savetype Error"));
   }
 }
 
@@ -2598,7 +2598,7 @@ void readFram(byte flashramType) {
     // Read Flashram
     readSram(131072, flashramType);
   } else {
-    print_Error(F("Savetype Error"), true);
+    print_FatalError(F("Savetype Error"));
   }
 }
 
@@ -2760,7 +2760,7 @@ void getFramType() {
       print_Msg(sdBuffer[c], HEX);
       print_Msg(F(", "));
     }
-    print_Error(F("Flashram unknown"), true);
+    print_FatalError(F("Flashram unknown"));
   }
 }
 
@@ -2793,7 +2793,7 @@ redumpnewfolder:
 redumpsamefolder:
   // Open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   // get current time
@@ -2966,10 +2966,10 @@ redumpsamefolder:
         sd.chdir(folder);
         // Delete old file
         if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-          print_Error(sd_error_STR, true);
+          print_FatalError(sd_error_STR);
         }
         if (!myFile.remove()) {
-          print_Error(F("Delete Error"), true);
+          print_FatalError(F("Delete Error"));
         }
         // Dump again
         display_Clear();
@@ -2992,7 +2992,7 @@ redumpsamefolder:
 void savesummary_N64(boolean checkfound, char crcStr[9], unsigned long timeElapsed) {
   // Open file on sd card
   if (!myFile.open("N64/ROM/n64log.txt", O_RDWR | O_CREAT | O_APPEND)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   //Write the info
@@ -3261,7 +3261,7 @@ void flashRepro_N64() {
 
     // Compare file size to flashrom size
     if ((fileSize / 1048576) > cartSize) {
-      print_Error(file_too_big_STR, true);
+      print_FatalError(file_too_big_STR);
     }
 
     // Erase needed sectors
@@ -3316,7 +3316,7 @@ void flashRepro_N64() {
           writeFlashrom_N64(sectorSize);
         }
       } else {
-        print_Error(F("sectorSize not set"), true);
+        print_FatalError(F("sectorSize not set"));
       }
 
       // Close the file:
@@ -3332,15 +3332,15 @@ void flashRepro_N64() {
       } else {
         print_Msg(writeErrors);
         print_Msg(F(" bytes "));
-        print_Error(did_not_verify_STR, false);
+        print_Error(did_not_verify_STR);
       }
     } else {
       // Close the file
       myFile.close();
-      print_Error(F("failed"), false);
+      print_Error(F("failed"));
     }
   } else {
-    print_Error(F("Can't open file"), false);
+    print_Error(F("Can't open file"));
   }
 
   // Prints string out of the common strings array either with or without newline
@@ -3542,7 +3542,7 @@ void idFlashrom_N64() {
     }
   }
   if ((flashid == 0x1240) && (strcmp(cartID, "1240") == 0)) {
-    print_Error(F("Please reseat cartridge"), true);
+    print_FatalError(F("Please reseat cartridge"));
   }
 }
 
@@ -4101,7 +4101,7 @@ void flashGameshark_N64() {
 
       // Compare file size to flashrom size
       if (fileSize > 262144) {
-        print_Error(file_too_big_STR, true);
+        print_FatalError(file_too_big_STR);
       }
 
       // SST 29LE010, chip erase not needed as this eeprom automaticly erases during the write cycle
@@ -4131,17 +4131,17 @@ void flashGameshark_N64() {
       } else {
         print_Msg(writeErrors);
         print_Msg(F(" bytes "));
-        print_Error(did_not_verify_STR, false);
+        print_Error(did_not_verify_STR);
       }
     } else {
-      print_Error(F("Can't open file"), false);
+      print_Error(F("Can't open file"));
     }
   }
   // If the ID is unknown show error message
   else {
     print_Msg(F("ID: "));
     println_Msg(flashid_str);
-    print_Error(F("Unknown flashrom"), false);
+    print_Error(F("Unknown flashrom"));
   }
 
   // Prints string out of the common strings array either with or without newline
@@ -4206,7 +4206,7 @@ void backupGameshark_N64() {
 
   // Open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   for (unsigned long currByte = romBase + 0xC00000; currByte < (romBase + 0xC00000 + 262144); currByte += 512) {

--- a/Cart_Reader/NES.ino
+++ b/Cart_Reader/NES.ino
@@ -514,7 +514,7 @@ void getMapping() {
 
   sd.chdir();
   if (!database.open("nes.txt", O_READ)) {
-    print_Error(F("Database file not found"), true);
+    print_FatalError(F("Database file not found"));
     // never reached
   }
 
@@ -766,7 +766,7 @@ void readRom_NES() {
 
   // Open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   //Initialize progress bar
@@ -825,7 +825,7 @@ void readRaw_NES() {
 
   // Open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   //Initialize progress bar
@@ -1203,7 +1203,7 @@ void outputNES() {
     display_Clear();
     println_Msg(F("PRG FILE FAILED!"));
     display_Update();
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   if (has_header) {
@@ -1223,7 +1223,7 @@ void outputNES() {
     display_Clear();
     println_Msg(F("NES FILE FAILED!"));
     display_Update();
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   if (has_header) {
@@ -4163,7 +4163,7 @@ void writeRAM() {
   display_Clear();
 
   if (ramsize == 0) {
-    print_Error(F("RAM SIZE 0K"), false);
+    print_Error(F("RAM SIZE 0K"));
   } else {
     fileBrowser(F("Select RAM File"));
     word base = 0x6000;
@@ -4379,7 +4379,7 @@ void writeRAM() {
       display_Update();
 
     } else {
-      print_Error(sd_error_STR, true);
+      print_FatalError(sd_error_STR);
     }
   }
 

--- a/Cart_Reader/NGP.ino
+++ b/Cart_Reader/NGP.ino
@@ -47,7 +47,7 @@ void setup_NGP() {
   if (getCartInfo_NGP())
     printCartInfo_NGP();
   else
-    print_Error(F("Cartridge read error"), true);
+    print_FatalError(F("Cartridge read error"));
 }
 
 void ngpMenu() {
@@ -215,7 +215,7 @@ void readROM_NGP(char* outPathBuf, size_t bufferSize) {
 
   // open file on sdcard
   if (!myFile.open(fileName, O_RDWR | O_CREAT))
-    print_Error(create_file_STR, true);
+    print_FatalError(create_file_STR);
 
   // write new folder number back to EEPROM
   foldern++;
@@ -265,7 +265,7 @@ void scanChip_NGP() {
 
   // open file on sdcard
   if (!myFile.open(fileName, O_RDWR | O_CREAT))
-    print_Error(create_file_STR, true);
+    print_FatalError(create_file_STR);
 
   // write new folder number back to EEPROM
   foldern++;

--- a/Cart_Reader/PCE.ino
+++ b/Cart_Reader/PCE.ino
@@ -543,7 +543,7 @@ void read_tennokoe_bank_PCE(int bank_index) {
 
   //open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(create_file_STR, true);
+    print_FatalError(create_file_STR);
   }
 
   pin_read_write_PCE();
@@ -683,7 +683,7 @@ void write_tennokoe_bank_PCE(int bank_index) {
       println_Msg(F("Verify failed..."));
       print_Msg(diffcnt);
       print_STR(_bytes_STR, 1);
-      print_Error(did_not_verify_STR, false);
+      print_Error(did_not_verify_STR);
     }
 
     pin_init_PCE();
@@ -694,7 +694,7 @@ void write_tennokoe_bank_PCE(int bank_index) {
     display_Update();
     wait();
   } else {
-    print_Error(F("File doesn't exist"), false);
+    print_Error(F("File doesn't exist"));
   }
 }
 
@@ -737,7 +737,7 @@ void read_rom_PCE(void) {
 
   //open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(create_file_STR, true);
+    print_FatalError(create_file_STR);
   }
 
   pin_read_write_PCE();

--- a/Cart_Reader/PCW.ino
+++ b/Cart_Reader/PCW.ino
@@ -185,7 +185,7 @@ void pcwMenu() {
         print_STR(error_STR, 0);
         print_Msg(writeErrors);
         print_STR(_bytes_STR, 1);
-        print_Error(did_not_verify_STR, false);
+        print_Error(did_not_verify_STR);
       }
       break;
 
@@ -478,7 +478,7 @@ void readROM_PCW() {
   EEPROM_writeAnything(0, foldern);
 
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
   read_setup_PCW();
   for (unsigned long address = 0; address < 0x400000; address += 512) {  // 4MB
@@ -521,7 +521,7 @@ void readMultiROM_PCW() {
   EEPROM_writeAnything(0, foldern);
 
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
   display_Clear();
   println_Msg(F("READING MULTI-PACK"));
@@ -579,7 +579,7 @@ void readSRAM_PCW() {  // readSRAM_1A()
   EEPROM_writeAnything(0, foldern);
 
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
   display_Clear();
   read_setup_PCW();
@@ -626,10 +626,10 @@ void writeSRAM_PCW() {
       print_STR(done_STR, 1);
       display_Update();
     } else {
-      print_Error(sd_error_STR, true);
+      print_FatalError(sd_error_STR);
     }
   } else {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
   display_Clear();
 }
@@ -652,7 +652,7 @@ unsigned long verifySRAM_PCW() {
     }
     myFile.close();
   } else {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   return writeErrors;

--- a/Cart_Reader/SFM.ino
+++ b/Cart_Reader/SFM.ino
@@ -109,7 +109,7 @@ void sfmGameMenu() {
           println_Msg(F(" Timeout"));
           println_Msg(readBank_SFM(0, 0x2400), HEX);
           println_Msg(F(""));
-          print_Error(F("Powercycle SFM cart"), true);
+          print_FatalError(F("Powercycle SFM cart"));
         }
       }
       // Copy gameCode to romName in case of japanese chars in romName
@@ -132,7 +132,7 @@ void sfmGameMenu() {
       mode = mode_SFM_Game;
     }
   } else {
-    print_Error(F("Switch to HiRom failed"), false);
+    print_Error(F("Switch to HiRom failed"));
   }
 }
 
@@ -177,7 +177,7 @@ void sfmGameOptions() {
         print_STR(error_STR, 0);
         print_Msg(wrErrors);
         print_STR(_bytes_STR, 1);
-        print_Error(did_not_verify_STR, false);
+        print_Error(did_not_verify_STR);
       }
       break;
 
@@ -246,7 +246,7 @@ void sfmFlashMenu() {
         // Read flash
         readFlash_SFM();
       } else {
-        print_Error(F("Switch to HiRom failed"), false);
+        print_Error(F("Switch to HiRom failed"));
       }
       break;
 
@@ -316,13 +316,13 @@ void sfmFlashMenu() {
             resetFlash_SFM(0xC0);
             resetFlash_SFM(0xE0);
           } else {
-            print_Error(F("Error: Wrong Flash ID"), true);
+            print_FatalError(F("Error: Wrong Flash ID"));
           }
         } else {
-          print_Error(F("Error: Wrong Flash ID"), true);
+          print_FatalError(F("Error: Wrong Flash ID"));
         }
       } else {
-        print_Error(F("failed"), false);
+        print_Error(F("failed"));
       }
       break;
 
@@ -353,13 +353,13 @@ void sfmFlashMenu() {
             resetFlash_SFM(0xC0);
             resetFlash_SFM(0xE0);
           } else {
-            print_Error(F("Error: Wrong Flash ID"), true);
+            print_FatalError(F("Error: Wrong Flash ID"));
           }
         } else {
-          print_Error(F("Error: Wrong Flash ID"), true);
+          print_FatalError(F("Error: Wrong Flash ID"));
         }
       } else {
-        print_Error(F("failed"), false);
+        print_Error(F("failed"));
       }
       break;
 
@@ -576,7 +576,7 @@ void setup_SFM() {
 #ifdef clockgen_installed
   else {
     display_Clear();
-    print_Error(F("Clock Generator not found"), true);
+    print_FatalError(F("Clock Generator not found"));
   }
 #endif
 
@@ -598,7 +598,7 @@ void setup_SFM() {
       println_Msg(F("Hirom All Timeout"));
       println_Msg(F(""));
       println_Msg(F(""));
-      print_Error(F("Powercycle SFM cart"), true);
+      print_FatalError(F("Powercycle SFM cart"));
     }
   }
 }
@@ -903,7 +903,7 @@ void readROM_SFM() {
 
   //open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(create_file_STR, true);
+    print_FatalError(create_file_STR);
   }
 
   // Check if LoROM or HiROM...
@@ -1078,7 +1078,7 @@ void writeFlash_SFM(int startBank, uint32_t pos) {
     myFile.close();
     println_Msg("");
   } else {
-    print_Error(open_file_STR, true);
+    print_FatalError(open_file_STR);
   }
 }
 
@@ -1221,7 +1221,7 @@ unsigned long verifyFlash_SFM(int startBank, uint32_t pos) {
   } else {
     // SD Error
     verified = 999999;
-    print_Error(F("Can't open file on SD"), false);
+    print_Error(F("Can't open file on SD"));
   }
   // Return 0 if verified ok, or number of errors
   return verified;
@@ -1241,7 +1241,7 @@ void readFlash_SFM() {
 
   // Open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(create_file_STR, true);
+    print_FatalError(create_file_STR);
   }
   if (romType) {
     for (byte currBank = 0xC0; currBank < 0xC0 + numBanks; currBank++) {
@@ -1385,7 +1385,7 @@ void readMapping() {
 
   //open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   // Read the mapping info out of the 1st chip
@@ -1471,10 +1471,10 @@ void eraseMapping(byte startBank) {
       dataIn();
       controlIn_SFM();
     } else {
-      print_Error(F("Error: Wrong Flash ID"), true);
+      print_FatalError(F("Error: Wrong Flash ID"));
     }
   } else {
-    print_Error(F("Unlock failed"), true);
+    print_FatalError(F("Unlock failed"));
   }
 }
 
@@ -1599,17 +1599,17 @@ void writeMapping_SFM(byte startBank, uint32_t pos) {
         myFile.close();
         println_Msg("");
       } else {
-        print_Error(F("Can't open file on SD"), false);
+        print_Error(F("Can't open file on SD"));
       }
 
       // Switch to read
       dataIn();
       controlIn_SFM();
     } else {
-      print_Error(F("Error: Wrong Flash ID"), true);
+      print_FatalError(F("Error: Wrong Flash ID"));
     }
   } else {
-    print_Error(F("Unlock failed"), true);
+    print_FatalError(F("Unlock failed"));
   }
 }
 
@@ -1717,7 +1717,7 @@ void write_SFM(int startBank, uint32_t pos) {
           println_Msg(F("OK"));
           display_Update();
         } else {
-          print_Error(F("Could not erase flash"), true);
+          print_FatalError(F("Could not erase flash"));
         }
       }
       // Write flash
@@ -1737,13 +1737,13 @@ void write_SFM(int startBank, uint32_t pos) {
         print_STR(error_STR, 0);
         print_Msg(writeErrors);
         print_STR(_bytes_STR, 1);
-        print_Error(did_not_verify_STR, true);
+        print_FatalError(did_not_verify_STR);
       }
     } else {
-      print_Error(F("Error: Wrong Flash ID"), true);
+      print_FatalError(F("Error: Wrong Flash ID"));
     }
   } else {
-    print_Error(F("Unlock failed"), true);
+    print_FatalError(F("Unlock failed"));
   }
 }
 

--- a/Cart_Reader/SMS.ino
+++ b/Cart_Reader/SMS.ino
@@ -593,7 +593,7 @@ void readROM_SMS() {
 
   // Open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   // set default bank size to 16KB
@@ -678,7 +678,7 @@ void readSRAM_SMS() {
 
   // Open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
   // Write the whole 32KB
   // When there is only 8KB of SRAM, the contents should be duplicated
@@ -705,7 +705,7 @@ void writeSRAM_SMS() {
   display_Clear();
 
   if (false) {
-    print_Error(F("DISABLED"), false);
+    print_Error(F("DISABLED"));
   } else {
     fileBrowser(F("Select file"));
 
@@ -748,7 +748,7 @@ void writeSRAM_SMS() {
       print_STR(done_STR, 1);
       display_Update();
     } else {
-      print_Error(sd_error_STR, true);
+      print_FatalError(sd_error_STR);
     }
   }
 

--- a/Cart_Reader/SNES.ino
+++ b/Cart_Reader/SNES.ino
@@ -216,7 +216,7 @@ void snesMenu() {
           display_Update();
         } else {
           display_Clear();
-          print_Error(F("Does not have ROM"), false);
+          print_Error(F("Does not have ROM"));
         }
       }
       break;
@@ -229,7 +229,7 @@ void snesMenu() {
         readSRAM();
       } else {
         display_Clear();
-        print_Error(F("Does not have SRAM"), false);
+        print_Error(F("Does not have SRAM"));
       }
       break;
 
@@ -248,11 +248,11 @@ void snesMenu() {
           print_STR(error_STR, 0);
           print_Msg(wrErrors);
           print_STR(_bytes_STR, 1);
-          print_Error(did_not_verify_STR, false);
+          print_Error(did_not_verify_STR);
         }
       } else {
         display_Clear();
-        print_Error(F("Does not have SRAM"), false);
+        print_Error(F("Does not have SRAM"));
       }
       break;
 
@@ -283,11 +283,11 @@ void snesMenu() {
           print_STR(error_STR, 0);
           print_Msg(wrErrors);
           print_STR(_bytes_STR, 1);
-          print_Error(did_not_verify_STR, false);
+          print_Error(did_not_verify_STR);
         }
       } else {
         display_Clear();
-        print_Error(F("Does not have SRAM"), false);
+        print_Error(F("Does not have SRAM"));
       }
       break;
 
@@ -465,7 +465,7 @@ void setup_Snes() {
 #ifdef clockgen_installed
   else {
     display_Clear();
-    print_Error(F("Clock Generator not found"), true);
+    print_FatalError(F("Clock Generator not found"));
   }
 #endif
 
@@ -1213,7 +1213,7 @@ unsigned int calc_checksum(char* fileName, char* folder) {
     return (calcChecksum);
   } else {
     // Else show error
-    print_Error(F("DUMP ROM 1ST"), false);
+    print_Error(F("DUMP ROM 1ST"));
     return 0;
   }
 }
@@ -1240,7 +1240,7 @@ boolean compare_checksum() {
   } else {
     print_Msg(F(" != "));
     println_Msg(checksumStr);
-    print_Error(F("Invalid Checksum"), false);
+    print_Error(F("Invalid Checksum"));
     display_Update();
     return 0;
   }
@@ -1275,7 +1275,7 @@ void readROM_SNES() {
 
   //open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(create_file_STR, true);
+    print_FatalError(create_file_STR);
   }
 
   //Dump Derby Stallion '96 (Japan) Actual Size is 24Mb
@@ -1604,7 +1604,7 @@ void writeSRAM(boolean browseFile) {
     display_Update();
 
   } else {
-    print_Error(F("File doesnt exist"), false);
+    print_Error(F("File doesnt exist"));
   }
 }
 
@@ -1628,7 +1628,7 @@ void readSRAM() {
 
   //open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
   int sramBanks = 0;
   if (romType == LO) {
@@ -1904,7 +1904,7 @@ unsigned long verifySRAM() {
         print_STR(error_STR, 0);
         print_Msg(writeErrors);
         print_STR(_bytes_STR, 1);
-        print_Error(did_not_verify_STR, false);
+        print_Error(did_not_verify_STR);
       }
       display_Update();
       wait();
@@ -1921,7 +1921,7 @@ unsigned long verifySRAM() {
     myFile.close();
     return writeErrors;
   } else {
-    print_Error(F("Can't open file"), false);
+    print_Error(F("Can't open file"));
     return 1;
   }
 }

--- a/Cart_Reader/SV.ino
+++ b/Cart_Reader/SV.ino
@@ -85,7 +85,7 @@ void svMenu() {
         print_STR(error_STR, 0);
         print_Msg(wrErrors);
         print_STR(_bytes_STR, 1);
-        print_Error(did_not_verify_STR, false);
+        print_Error(did_not_verify_STR);
       }
       wait();
       break;
@@ -122,7 +122,7 @@ void setup_SV() {
 #ifdef clockgen_installed
   else {
     display_Clear();
-    print_Error(F("Clock Generator not found"), true);
+    print_FatalError(F("Clock Generator not found"));
   }
 #endif
 
@@ -300,7 +300,7 @@ void readSRAM_SV() {
 
   //open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   readBank_SV(0x10, 0);  // Preconfigure to fix corrupt 1st byte
@@ -371,7 +371,7 @@ void writeSRAM_SV() {
     println_Msg(F("SRAM writing finished"));
     display_Update();
   } else {
-    print_Error(F("File doesnt exist"), false);
+    print_Error(F("File doesnt exist"));
   }
 }
 
@@ -402,7 +402,7 @@ unsigned long verifySRAM_SV() {
     myFile.close();
     return writeErrors;
   } else {
-    print_Error(F("Can't open file"), false);
+    print_Error(F("Can't open file"));
     return 1;
   }
 }
@@ -438,7 +438,7 @@ void readROM_SV() {
 
   //open file on sd card
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(create_file_STR, true);
+    print_FatalError(create_file_STR);
   }
 
   // Read Banks
@@ -470,7 +470,7 @@ void writeROM_SV(void) {
   //if CRC is not 8B86, BS-X cart is not inserted. Display error and reset
   if (strcmp("8B86", checksumStr) != 0) {
     display_Clear();
-    print_Error(F("Error: Must use BS-X cart"), true);
+    print_FatalError(F("Error: Must use BS-X cart"));
   }
 
   //Display file Browser and wait user to select a file. Size must be 1MB.
@@ -575,7 +575,7 @@ void writeROM_SV(void) {
     wait();
 
   } else {
-    print_Error(F("File doesn't exist"), false);
+    print_Error(F("File doesn't exist"));
   }
 }
 

--- a/Cart_Reader/VBOY.ino
+++ b/Cart_Reader/VBOY.ino
@@ -122,7 +122,7 @@ void vboyMenu() {
         readSRAM_VB();
         sd.chdir("/");
       } else {
-        print_Error(F("Cart has no SRAM"), false);
+        print_Error(F("Cart has no SRAM"));
       }
 #if (defined(enable_OLED) || defined(enable_LCD))
       // Wait for user input
@@ -149,10 +149,10 @@ void vboyMenu() {
           print_STR(error_STR, 0);
           print_Msg(writeErrors);
           print_STR(_bytes_STR, 1);
-          print_Error(did_not_verify_STR, false);
+          print_Error(did_not_verify_STR);
         }
       } else {
-        print_Error(F("Cart has no SRAM"), false);
+        print_Error(F("Cart has no SRAM"));
       }
 #if (defined(enable_OLED) || defined(enable_LCD))
       // Wait for user input
@@ -429,7 +429,7 @@ void readROM_VB() {
   EEPROM_writeAnything(0, foldern);
 
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   word d = 0;
@@ -500,7 +500,7 @@ void writeSRAM_VB() {
     print_STR(done_STR, 1);
     display_Update();
   } else {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
   dataIn_VB();
 }
@@ -520,7 +520,7 @@ void readSRAM_VB() {
   EEPROM_writeAnything(0, foldern);
 
   if (!myFile.open(fileName, O_RDWR | O_CREAT)) {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
   for (unsigned long currBuffer = 0; currBuffer < sramSize; currBuffer += 512) {
     for (int currByte = 0; currByte < 512; currByte++) {
@@ -554,7 +554,7 @@ unsigned long verifySRAM_VB() {
     }
     myFile.close();
   } else {
-    print_Error(sd_error_STR, true);
+    print_FatalError(sd_error_STR);
   }
 
   return writeErrors;

--- a/Cart_Reader/WS.ino
+++ b/Cart_Reader/WS.ino
@@ -77,10 +77,10 @@ void setup_WS() {
 
   // unlock MMC
   //  if (!unlockMMC2003_WS())
-  //    print_Error(F("Can't initial MMC"), true);
+  //    print_FatalError(F("Can't initial MMC"));
 
   //  if (getCartInfo_WS() != 0xea)
-  //    print_Error(F("Rom header read error"), true);
+  //    print_FatalError(F("Rom header read error"));
 
   println_Msg(F("Initializing..."));
   display_Update();
@@ -496,7 +496,7 @@ void readROM_WS(char *outPathBuf, size_t bufferSize) {
 
   // open file on sdcard
   if (!myFile.open(fileName, O_RDWR | O_CREAT))
-    print_Error(create_file_STR, true);
+    print_FatalError(create_file_STR);
 
   // write new folder number back to EEPROM
   foldern++;
@@ -563,7 +563,7 @@ void readSRAM_WS() {
   EEPROM_writeAnything(0, foldern);
 
   if (!myFile.open(fileName, O_RDWR | O_CREAT))
-    print_Error(create_file_STR, true);
+    print_FatalError(create_file_STR);
 
   uint32_t bank_size = (sramSize << 7);
   uint16_t end_bank = (bank_size >> 16);  // 64KB per bank
@@ -635,10 +635,10 @@ void verifySRAM_WS() {
       print_STR(error_STR, 0);
       print_Msg(write_errors);
       print_STR(_bytes_STR, 1);
-      print_Error(did_not_verify_STR, false);
+      print_Error(did_not_verify_STR);
     }
   } else {
-    print_Error(F("File doesn't exist"), false);
+    print_Error(F("File doesn't exist"));
   }
 }
 
@@ -684,7 +684,7 @@ void writeSRAM_WS() {
     println_Msg(F("Writing finished"));
     display_Update();
   } else {
-    print_Error(F("File doesn't exist"), false);
+    print_Error(F("File doesn't exist"));
   }
 }
 
@@ -708,7 +708,7 @@ void readEEPROM_WS() {
   EEPROM_writeAnything(0, foldern);
 
   if (!myFile.open(fileName, O_RDWR | O_CREAT))
-    print_Error(create_file_STR, true);
+    print_FatalError(create_file_STR);
 
   uint32_t eepromSize = (sramSize << 7);
   uint32_t bufSize = (eepromSize < 512 ? eepromSize : 512);
@@ -789,10 +789,10 @@ void verifyEEPROM_WS() {
       print_STR(error_STR, 0);
       print_Msg(write_errors);
       print_STR(_bytes_STR, 1);
-      print_Error(did_not_verify_STR, false);
+      print_Error(did_not_verify_STR);
     }
   } else {
-    print_Error(F("File doesn't exist"), false);
+    print_Error(F("File doesn't exist"));
   }
 }
 
@@ -843,7 +843,7 @@ void writeEEPROM_WS() {
 
     print_STR(done_STR, 1);
   } else {
-    print_Error(F("File doesn't exist"), false);
+    print_Error(F("File doesn't exist"));
   }
 }
 
@@ -857,7 +857,7 @@ void writeWitchOS_WS() {
   dataIn_WS();
   if (readWord_WS(0xe0004) || readWord_WS(0xe4004) || readWord_WS(0xec004) || readWord_WS(0xee004)) {
     display_Clear();
-    print_Error(F("OS sectors are protected!"), false);
+    print_Error(F("OS sectors are protected!"));
   } else {
     filePath[0] = 0;
     sd.chdir("/");
@@ -932,7 +932,7 @@ void writeWitchOS_WS() {
 
       print_STR(done_STR, 1);
     } else {
-      print_Error(F("File doesn't exist"), false);
+      print_Error(F("File doesn't exist"));
     }
   }
 
@@ -976,7 +976,7 @@ boolean compareChecksum_WS(const char *wsFilePath) {
   display_Update();
 
   if (!myFile.open(wsFilePath, O_READ)) {
-    print_Error(F("Failed to open file"), false);
+    print_Error(F("Failed to open file"));
     return 0;
   }
 
@@ -1013,7 +1013,7 @@ boolean compareChecksum_WS(const char *wsFilePath) {
     display_Update();
     return 1;
   } else {
-    print_Error(F("Checksum Error"), false);
+    print_Error(F("Checksum Error"));
     return 0;
   }
 }

--- a/Cart_Reader/WSV.ino
+++ b/Cart_Reader/WSV.ino
@@ -205,7 +205,7 @@ void readROM_WSV() {
 
   // open file on sdcard
   if (!myFile.open(fileName, O_RDWR | O_CREAT))
-    print_Error(create_file_STR, true);
+    print_FatalError(create_file_STR);
 
   // write new folder number back to EEPROM
   foldern++;
@@ -516,7 +516,7 @@ void setCart_WSV() {
       }
     }
   } else {
-    print_Error(F("Database file not found"), true);
+    print_FatalError(F("Database file not found"));
   }
 }
 #endif


### PR DESCRIPTION
The N64 code was heavily modified, going from 3 sets of functions handling the JoyBus in the source code (2 in any build) to a single one (both in source and in binaries). The low-level JoyBus functions are now in assembler, which frees enough time to pack received bitstream into bytes instead of having to do so as a second step after the transfer. Also, convert sequences of NOPs into a delay loop, for better program space efficiency.

Overall, this patch set shrinks the HW3 build by 4.4kB of program space and just shy of 400B of global ram space. The amount of space saved should be comparable on other hardware revisions.
