### PR TITLE
Re-fix compiler warnings

### DIFF
--- a/Cart_Reader/SFM.ino
+++ b/Cart_Reader/SFM.ino
@@ -912,7 +912,7 @@ void readROM_SFM() {
     display_Update();
 
     // Read up to 96 banks starting at bank 0×00.
-    for (byte currBank = 0; currBank < numBanks; currBank++) {
+    for (word currBank = 0; currBank < numBanks; currBank++) {
       // Dump the bytes to SD 512B at a time
       for (long currByte = 32768; currByte < 65536; currByte += 512) {
         for (int c = 0; c < 512; c++) {
@@ -1064,7 +1064,7 @@ void writeFlash_SFM(int startBank, uint32_t pos) {
       draw_progressbar(0, totalProgressBar);
 
       // Write lorom
-      for (byte currBank = 0; currBank < numBanks; currBank++) {
+      for (word currBank = 0; currBank < numBanks; currBank++) {
         for (unsigned long currByte = 0x8000; currByte < 0x10000; currByte += 128) {
           myFile.read(sdBuffer, 128);
           // Write command sequence
@@ -1179,7 +1179,7 @@ byte blankcheck_SFM(int startBank) {
       }
     }
   } else {
-    for (byte currBank = 0; currBank < numBanks; currBank++) {
+    for (word currBank = 0; currBank < numBanks; currBank++) {
       for (unsigned long currByte = 0x8000; currByte < 0x10000; currByte++) {
         if (readBank_SFM(currBank, currByte) != 0xFF) {
           currBank = numBanks;
@@ -1219,7 +1219,7 @@ unsigned long verifyFlash_SFM(int startBank, uint32_t pos) {
         }
       }
     } else {
-      for (byte currBank = 0; currBank < numBanks; currBank++) {
+      for (word currBank = 0; currBank < numBanks; currBank++) {
         for (unsigned long currByte = 0x8000; currByte < 0x10000; currByte += 512) {
           // Fill SDBuffer
           myFile.read(sdBuffer, 512);
@@ -1268,7 +1268,7 @@ void readFlash_SFM() {
       }
     }
   } else {
-    for (byte currBank = 0; currBank < numBanks; currBank++) {
+    for (word currBank = 0; currBank < numBanks; currBank++) {
       for (unsigned long currByte = 0x8000; currByte < 0x10000; currByte += 512) {
         for (int c = 0; c < 512; c++) {
           sdBuffer[c] = readBank_SFM(currBank, currByte + c);

--- a/Cart_Reader/SNES.ino
+++ b/Cart_Reader/SNES.ino
@@ -699,6 +699,24 @@ void readHiRomBanks(unsigned int start, unsigned int total, FsFile* file) {
 void getCartInfo_SNES() {
   boolean manualConfig = 0;
 
+  //Prime SA1 cartridge
+  PORTL = 192;
+  for (uint16_t currByte = 0; currByte < 1024; currByte++) {
+    PORTF = currByte & 0xFF;
+    PORTK = currByte >> 8;
+
+    // Wait for the Byte to appear on the data bus
+    // Arduino running at 16Mhz -> one nop = 62.5ns
+    // slowRom is good for 200ns, fastRom is <= 120ns; S-CPU best case read speed: 3.57MHz / 280ns
+    // let's be conservative and use 6 x 62.5 = 375ns
+    NOP;
+    NOP;
+    NOP;
+    NOP;
+    NOP;
+    NOP;
+  }
+
   // Print start page
   if (checkcart_SNES() == 0) {
     // Checksum either corrupt or 0000

--- a/Cart_Reader/SNES.ino
+++ b/Cart_Reader/SNES.ino
@@ -1344,7 +1344,7 @@ void readROM_SNES() {
     controlIn_SNES();
     byte initialSOMap = readBank_SNES(0, 18439);
 
-    for (byte currMemmap = 0; currMemmap < (numBanks / 16); currMemmap++) {
+    for (word currMemmap = 0; currMemmap < (numBanks / 16); currMemmap++) {
 
       dataOut();
       controlOut_SNES();


### PR DESCRIPTION
Similar to the parts of cc17c70e304fb106b0399b333f86fcc68d70dc32 which touch SFM.ino and SNES.ino . Plus another hunk that I am not sure was correct to discard.