### PR TITLE
Fix Sonic & Knuckles

### DIFF
--- a/Cart_Reader/MD.ino
+++ b/Cart_Reader/MD.ino
@@ -721,6 +721,7 @@ void getCartInfo_MD() {
   SnKmode = 0;
   if (chksum == 0xDFB3) {
     char id[15];
+    memset(id, 0, 15);
 
     // Get ID
     for (byte c = 0; c < 14; c += 2) {
@@ -737,6 +738,7 @@ void getCartInfo_MD() {
     //Sonic & Knuckles ID:GM MK-1563 -00
     if (!strcmp("GM MK-1563 -00", id)) {
       char labelLockon[17];
+      memset(labelLockon, 0, 17);
 
       // Get labelLockon
       for (byte c = 0; c < 16; c += 2) {
@@ -753,6 +755,7 @@ void getCartInfo_MD() {
       // check Lock-on game presence
       if (!(strcmp("SEGA MEGA DRIVE ", labelLockon) & strcmp("SEGA GENESIS    ", labelLockon))) {
         char idLockon[15];
+        memset(idLockon, 0, 15);
 
         // Lock-on cart checksum
         chksumLockon = readWord_MD(0x1000C7);
@@ -771,10 +774,10 @@ void getCartInfo_MD() {
           idLockon[c + 1] = loByte;
         }
 
-        if (!(strncmp("GM 00001009-0", idLockon, 13) & strncmp("GM 00004049-0", idLockon, 13))) {
+        if (!strncmp("GM 00001009-0", idLockon, 13) || !strncmp("GM 00004049-0", idLockon, 13)) {
           //Sonic1 ID:GM 00001009-0? or GM 00004049-0?
           SnKmode = 2;
-        } else if (!(strcmp("GM 00001051-00", idLockon) & strcmp("GM 00001051-01", idLockon) & strcmp("GM 00001051-02", idLockon))) {
+        } else if (!strcmp("GM 00001051-00", idLockon) || !strcmp("GM 00001051-01", idLockon) || !strcmp("GM 00001051-02", idLockon)) {
           //Sonic2 ID:GM 00001051-00 or GM 00001051-01 or GM 00001051-02
           SnKmode = 3;
 
@@ -1375,20 +1378,14 @@ void readROM_MD() {
     display_Update();
   }
 
-  // Calculate and compare CRC32 with nointro
-  if (is32x)
-    //database, crcString, renamerom, offset
-    compareCRC("32x.txt", 0, 1, 0);
-  else
-    compareCRC("md.txt", 0, 1, 0);
-
   // More checksums
   if (SnKmode >= 2) {
+    print_Msg(F("Lock-on checksum..."));
     if (chksumLockon == calcCKSLockon) {
-      println_Msg(F("Checksum2 OK"));
+      println_Msg(F("OK"));
       display_Update();
     } else {
-      print_Msg(F("Checksum2 Error: "));
+      print_Msg(F("Error"));
       char calcsumStr[5];
       sprintf(calcsumStr, "%04X", calcCKSLockon);
       println_Msg(calcsumStr);
@@ -1397,11 +1394,12 @@ void readROM_MD() {
     }
   }
   if (SnKmode == 3) {
+    print_Msg(F("Adittional checksum..."));
     if (chksumSonic2 == calcCKSSonic2) {
-      println_Msg(F("Checksum3 OK"));
+      println_Msg(F("OK"));
       display_Update();
     } else {
-      print_Msg(F("Checksum3 Error: "));
+      print_Msg(F("Error"));
       char calcsumStr[5];
       sprintf(calcsumStr, "%04X", calcCKSSonic2);
       println_Msg(calcsumStr);
@@ -1409,6 +1407,14 @@ void readROM_MD() {
       display_Update();
     }
   }
+
+  // Calculate and compare CRC32 with nointro
+  if (is32x)
+    //database, crcString, renamerom, offset
+    compareCRC("32x.txt", 0, 1, 0);
+  else
+    compareCRC("md.txt", 0, 1, 0);
+
 }
 
 /******************************************


### PR DESCRIPTION
Fixed a problem that lock-on games in "Sonic & Knuckles" is not recognized. Apparently, the compiler's behavior for variable initialization has changed.

- Added initialization of char variable.
- Fixed the judgment method of string comparison.
- Updated checksum text and position.
