### PR TITLE
Fix SNES "Kakinoki Shougi (Japan)"

### DIFF
--- a/Cart_Reader/SFM.ino
+++ b/Cart_Reader/SFM.ino
@@ -161,6 +161,7 @@ void sfmGameOptions() {
       sd.chdir("/");
       readROM_SFM();
       compare_checksum();
+      compareCRC("snes.txt", 0, 1, 0);
       break;
 
     // Write sram

--- a/Cart_Reader/SNES.ino
+++ b/Cart_Reader/SNES.ino
@@ -1246,13 +1246,6 @@ boolean compare_checksum() {
   print_Msg(F("Checksum... "));
   display_Update();
 
-  strcpy(fileName, romName);
-  strcat(fileName, ".sfc");
-
-  // last used rom folder
-  EEPROM_readAnything(0, foldern);
-  sprintf(folder, "SNES/ROM/%s/%d", romName, foldern - 1);
-
   char calcsumStr[5];
   sprintf(calcsumStr, "%04X", calc_checksum(fileName, folder));
   print_Msg(calcsumStr);

--- a/sd/snes.txt
+++ b/sd/snes.txt
@@ -4214,7 +4214,7 @@ Kaizou Choujin Shubibinman Zero (Japan).sfc
 E59E1096,84AF,3D44B149,01,004
 
 Kakinoki Shougi (Japan).sfc
-BC1A265F,F70B,3BA48939,12,024
+9E2C5CE4,F70B,08BF4E75,16,032
 
 Kamaitachi no Yoru (Japan).sfc
 71C631AA,815C,7D1A59F8,24,096


### PR DESCRIPTION
Fix for "Kakinoki Shougi (Japan)"
Doing compareCRC when reading game from SFM.
Don't rename when doing checksum, just use filename and folder.