### PR TITLE
Add support for Dinoforce (World)

### DIFF
--- a/Cart_Reader/PCE.ino
+++ b/Cart_Reader/PCE.ino
@@ -406,6 +406,10 @@ uint32_t detect_rom_size_PCE(void) {
     if (read_byte_PCE(0x1F26) == 'P' && read_byte_PCE(0x1F27) == 'O' && read_byte_PCE(0x1F28) == 'P' && read_byte_PCE(0x1F29) == 'U' && read_byte_PCE(0x1F2A) == 'L' && read_byte_PCE(0x1F2B) == 'O' && read_byte_PCE(0x1F2C) == 'U' && read_byte_PCE(0x1F2D) == 'S') {
       rom_size = 512;
     }
+    //Dinoforce (World)
+    if (read_byte_PCE(0x15A) == 'D' && read_byte_PCE(0x15B) == 'I' && read_byte_PCE(0x15C) == 'N' && read_byte_PCE(0x15D) == 'O' && read_byte_PCE(0x15E) == '-' && read_byte_PCE(0x15F) == 'F' && read_byte_PCE(0x160) == 'O' && read_byte_PCE(0x161) == 'R' && read_byte_PCE(0x162) == 'C' && read_byte_PCE(0x163) == 'E') {
+      rom_size = 512;
+    }
   }
 
   return rom_size;

--- a/sd/pce.txt
+++ b/sd/pce.txt
@@ -328,6 +328,9 @@ Die Hard (Japan).pce
 Digital Champ (World) (En,Ja) (WiiU Virtual Console).pce
 17BA3032
 
+Dinoforce (World) (Aftermarket) (Unl).pce
+334300B3
+
 Don Doko Don! (Japan).pce
 F42AA73E
 


### PR DESCRIPTION
Chip is 1MB, app data only on 512kB.