### PR TITLE
Update WSV.ino

### DIFF
--- a/Cart_Reader/WSV.ino
+++ b/Cart_Reader/WSV.ino
@@ -106,7 +106,7 @@ static const char wsvMenuItem3[] PROGMEM = "Set Size";
 static const char* const menuOptionsSV[] PROGMEM = { wsvMenuItem1, wsvMenuItem2, wsvMenuItem3, string_reset2 };
 
 void wsvMenu() {
-  setVoltage(VOLTS_SET_5V);
+  setVoltage(VOLTS_SET_3V3);
   convertPgm(menuOptionsSV, 4);
   uint8_t mainMenu = question_box(F("SUPERVISION MENU"), menuOptions, 4, 0);
 


### PR DESCRIPTION
Watara Supervision uses 3V to correctly read carts.