### PR TITLE
GBA: Fixes ROM name length and reading 32 MB carts that use EEPROM saves

### DIFF
--- a/Cart_Reader/GBA.ino
+++ b/Cart_Reader/GBA.ino
@@ -761,7 +761,7 @@ void getCartInfo_GBA() {
     }
 
     // Get name
-    buildRomName(romName, &sdBuffer[0xA0], 11);
+    buildRomName(romName, &sdBuffer[0xA0], 12);
 
     // Get ROM version
     romVersion = sdBuffer[0xBC];

--- a/Cart_Reader/GBA.ino
+++ b/Cart_Reader/GBA.ino
@@ -893,6 +893,18 @@ void readROM_GBA() {
     processedProgressBar += 512;
     draw_progressbar(processedProgressBar, totalProgressBar);
   }
+  
+  // Fix unmapped ROM area of cartridges with 32 MB ROM + EEPROM save type
+  if ((cartSize == 0x2000000) && ((saveType == 1) || (saveType == 2))) {
+    byte padding_byte[256];
+	char tempStr[32];
+	myFile.seek(0x1FFFEFF);
+	myFile.read(padding_byte, 1);
+	sprintf(tempStr, "Fixing ROM padding (0x%02X)", padding_byte[0]);
+	println_Msg(tempStr);
+	memset(padding_byte+1, padding_byte[0], 255);
+	myFile.write(padding_byte, 256);
+  }
 
   // Close the file:
   myFile.close();


### PR DESCRIPTION
Building the Game Boy Advance ROM name was fixed; it was short by one character.

Game Boy Advance cartridges with 32 MB of ROM and an EEPROM save type use the final 256 bytes in ROM space for EEPROM access (see [GBATEK: GBA Cart Backup EEPROM](https://problemkaputt.de/gbatek-gba-cart-backup-eeprom.htm)). This fix will restore the original padding data.