### PR TITLE
SNES.ino: Fix dumping Sound Novel Tsukuru (Japan)

### DIFF
--- a/Cart_Reader/SNES.ino
+++ b/Cart_Reader/SNES.ino
@@ -1300,8 +1300,8 @@ void readROM_SNES() {
     print_FatalError(create_file_STR);
   }
 
-  //Dump Derby Stallion '96 (Japan) Actual Size is 24Mb
-  if ((romType == LO) && (numBanks == 96) && (strcmp("CC86", checksumStr) == 0)) {
+  //Dump Derby Stallion '96 (Japan) and Sound Novel Tsukuru (Japan) - Actual Size is 24Mb
+  if ((romType == LO) && (numBanks == 96) && (strcmp("CC86", checksumStr) == 0) || strcmp("A77B", checksumStr) == 0) {
     // Read Banks 0x00-0x3F for the 1st/2nd MB
     for (int currBank = 0; currBank < 64; currBank++) {
       // Dump the bytes to SD 512B at a time


### PR DESCRIPTION
Sound Novel Tsukuru on my unit would not dump properly, with only the first two MB correctly dumped, and the last MB filled with FF bytes. After some digging, I found that there was a similar issue for Derby Stallion '96 with the same symptoms (both are carts with a slot for a Satellaview memory pack). I tried using its fix for Sound Novel Tsukuru, and was able to get a verified dump.

Relevant links:
https://github.com/sanni/cartreader/discussions/760#discussioncomment-5552247
https://github.com/sanni/cartreader/issues/799