### PR TITLE
fix reading mapping > 5 causes crc 0x0000000

### DIFF
--- a/Cart_Reader/C64.ino
+++ b/Cart_Reader/C64.ino
@@ -472,7 +472,7 @@ void readROM_C64() {
     // Read 0x8002 to determine whether Single Chip or Two Chip
     // IF 0x75 OR 0x83, THEN Two Chip ELSE Single Chip
 
-    case 5:          // Ocean 128K/256K/512K
+    case 5: {        // Ocean 128K/256K/512K
       GAME_ENABLE;   // LOW
       EXROM_ENABLE;  // LOW
       ROML_ENABLE;
@@ -508,7 +508,7 @@ void readROM_C64() {
       }
       disablePorts_C64();
       break;
-
+    }
     case 6:           // Expert Cartridge (8K)
       GAME_DISABLE;   // HIGH
       EXROM_DISABLE;  // HIGH


### PR DESCRIPTION
With my hw5  I have an issue dumping C64 carts with mappings of 6 or higher resulting in message "crc 0x0000000" with an empty file on sd card. I think the controller has an issue with declaring a variable inside the case statement but without its own scope. Afaik this should be solved by the compiler or result into an error at compiler stage. With the additional scoping the code works fine for me.