### PR TITLE
Handle Slaughter Sport title, update CRC32s

### DIFF
--- a/Cart_Reader/MD.ino
+++ b/Cart_Reader/MD.ino
@@ -1238,6 +1238,12 @@ void getCartInfo_MD() {
     sdBuffer[c + 1] = loByte;
   }
   romName[copyToRomName_MD(romName, sdBuffer, sizeof(romName) - 1)] = 0;
+  
+   // Check for Slaughter Sport
+  if (!strncmp("GMT5604600jJ", romName, 12) && (chksum == 0xFFFF)) {
+    strcpy(romName, "SLAUGHTERSPORT");
+    chksum = 0x6BAE;
+  }
 
   //Get Lock-on cart name
   if (SnKmode >= 2) {

--- a/sd/md.txt
+++ b/sd/md.txt
@@ -2162,7 +2162,7 @@ ESPN Baseball Tonight (USA).md
 96D8440C
 
 ESPN National Hockey Night (USA).md
-1D08828C
+401DC618
 
 ESPN National Hockey Night (USA) (Beta).md
 A427814A
@@ -5843,7 +5843,7 @@ Slap Fight MD (Japan) (En) (Beta).md
 DBB62949
 
 Slaughter Sport (USA).md
-AF9F9D9C
+AAB2C6C4
 
 Slime World (Japan).md
 7FF5529F


### PR DESCRIPTION
Slaughter Sport's header is misplaced, so the ID is read as the title, and the info where the ID should be is hex that doesn't convert to a string properly. This leads to it being created in the folder 'GMT5604600jJ'. It also gives a bad checksum error due to the misplaced header. This uses the correct title as found in the header instead, and corrects the checksum to verify properly, resulting in a proper folder name and checksum verificiation.

Also updating the CRC32 of this to match, as OSCR dumps it correctly but the known CRC32 was based on a trimmed version.

This also updates the CRC32 of ESPN National Hockey Night to the currently marked good one (verified with 3 carts on OSCR plus others' dumps).