### PR TITLE
Handle Slaughter Sport's bad header, update CRC32s

### DIFF
--- a/Cart_Reader/MD.ino
+++ b/Cart_Reader/MD.ino
@@ -1239,7 +1239,7 @@ void getCartInfo_MD() {
   }
   romName[copyToRomName_MD(romName, sdBuffer, sizeof(romName) - 1)] = 0;
   
-   // Check for Slaughter Sport
+  // Check for Slaughter Sport
   if (!strncmp("GMT5604600jJ", romName, 12) && (chksum == 0xFFFF)) {
     strcpy(romName, "SLAUGHTERSPORT");
     chksum = 0x6BAE;

--- a/Cart_Reader/MD.ino
+++ b/Cart_Reader/MD.ino
@@ -1238,6 +1238,12 @@ void getCartInfo_MD() {
     sdBuffer[c + 1] = loByte;
   }
   romName[copyToRomName_MD(romName, sdBuffer, sizeof(romName) - 1)] = 0;
+  
+   // Check for Slaughter Sport
+  if (!strncmp("GMT5604600jJ", romName, 12) && (chksum == 0xFFFF)) {
+    strcpy(romName, "SLAUGHTERSPORT");
+    chksum = 0x6BAE;
+  }
 
   //Get Lock-on cart name
   if (SnKmode >= 2) {

--- a/sd/md.txt
+++ b/sd/md.txt
@@ -2162,7 +2162,7 @@ ESPN Baseball Tonight (USA).md
 96D8440C
 
 ESPN National Hockey Night (USA).md
-1D08828C
+401DC618
 
 ESPN National Hockey Night (USA) (Beta).md
 A427814A
@@ -5843,7 +5843,7 @@ Slap Fight MD (Japan) (En) (Beta).md
 DBB62949
 
 Slaughter Sport (USA).md
-AF9F9D9C
+AAB2C6C4
 
 Slime World (Japan).md
 7FF5529F


### PR DESCRIPTION
Slaughter Sport's header is not at the right offsets, causing its ID to be read as the title, and creating it in a folder called GMT5604600jJ. It also reads the checksum as FFFF which isn't correct. The offset where the ID is read contains hex that would not convert to a string properly.

This corrects this so that it uses the title seen in the (misplaced) header, naming the folder correctly, and provides the correct checksum.

This also updates the CRC32 in the txt file as the previous was based on a trimmed version.

ESPN National Hockey Night's CRC32 is updated to the current known good one (tested with 3 carts on OSCR) as well.