### PR TITLE
Fix Slaughter Sport title, two CRC32s

### DIFF
--- a/Cart_Reader/MD.ino
+++ b/Cart_Reader/MD.ino
@@ -1239,6 +1239,12 @@ void getCartInfo_MD() {
   }
   romName[copyToRomName_MD(romName, sdBuffer, sizeof(romName) - 1)] = 0;
 
+  //Check for Slaughter Sport
+  if (!strncmp("GMT5604600jJ", romName, 12) && (chksum == 0xFFFF)) {
+    strcpy(romName, "SLAUGHTERSPORT");
+    chksum = 0x6BAE;
+  }
+
   //Get Lock-on cart name
   if (SnKmode >= 2) {
     char romNameLockon[12];

--- a/sd/md.txt
+++ b/sd/md.txt
@@ -2162,7 +2162,7 @@ ESPN Baseball Tonight (USA).md
 96D8440C
 
 ESPN National Hockey Night (USA).md
-1D08828C
+401DC618
 
 ESPN National Hockey Night (USA) (Beta).md
 A427814A
@@ -5843,7 +5843,7 @@ Slap Fight MD (Japan) (En) (Beta).md
 DBB62949
 
 Slaughter Sport (USA).md
-AF9F9D9C
+AAB2C6C4
 
 Slime World (Japan).md
 7FF5529F


### PR DESCRIPTION
Slaughter Sport has its header in the wrong location, causing the ID to be read as the title, resulting in a folder called 'GMT5604600jJ' - the offset read as the ID is hex that can't be displayed as a string. The offset containing the checksum is also FF FF.

This corrects the title and therefore the folder name to match what is in the header (albeit the wrong offset), as well as the checksum. It also corrects the CRC32 in the txt file which currently points to a trimmed version. I placed it right after the title is read as the other code using romName runs after the title has been properly read, rather than correcting it, so it seemed that corrections should be at the top. If others are found this could be a "//misplaced headers check" section rather than just Slaughter Sport.

ESPN Hockey Night CRC32 also updated to match No-Intro database.