### PR TITLE
remove duplicate code of seeking database files for letters

### DIFF
--- a/Cart_Reader/COLV.ino
+++ b/Cart_Reader/COLV.ino
@@ -377,24 +377,7 @@ void setCart_COL() {
 
   // Open database
   if (myFile.open("colv.txt", O_READ)) {
-    // Skip ahead to selected starting letter
-    if ((myLetter > 0) && (myLetter <= 26)) {
-      while (myFile.available()) {
-        // Read current name
-        get_line(gamename, &myFile, 96);
-
-        // Compare selected letter with first letter of current name until match
-        while (gamename[0] != 64 + myLetter) {
-          skip_line(&myFile);
-          skip_line(&myFile);
-          get_line(gamename, &myFile, 96);
-        }
-        break;
-      }
-
-      // Rewind one line
-      rewind_line(myFile);
-    }
+    seek_first_letter_in_database(myFile, myLetter);
 
     // Display database
     while (myFile.available()) {

--- a/Cart_Reader/Cart_Reader.ino
+++ b/Cart_Reader/Cart_Reader.ino
@@ -660,7 +660,7 @@ boolean compareCRC(const char* database, uint32_t crc32sum, boolean renamerom, i
             myFile.close();
           }
         } else {
-          println_Msg("OK");
+          println_Msg(FS(FSTRING_OK));
         }
         return 1;
         break;
@@ -676,6 +676,35 @@ boolean compareCRC(const char* database, uint32_t crc32sum, boolean renamerom, i
     return 0;
   }
   return 0;
+}
+
+// move file pointer to first game line with matching letter. If no match is found the last database entry is selected
+void seek_first_letter_in_database(FsFile& database, byte myLetter) {
+    char gamename_str[3];
+#ifdef ENABLE_GLOBAL_LOG
+    // Disable log to prevent unnecessary logging
+    println_Log(F("Select Mapping from List"));
+    dont_log = true;
+#endif
+    database.rewind();
+    // Skip ahead to selected starting letter
+    if ((myLetter > 0) && (myLetter <= 26)) {
+      myLetter += 'A' - 1;
+      do {
+        // Read current name
+        get_line(gamename_str, &database, 2);
+        // Skip data line
+        skip_line(&database);
+        // Skip empty line
+        skip_line(&database);
+
+      } while (database.available() && gamename_str[0] != myLetter);
+      rewind_line(database, 3);
+    }
+#ifdef ENABLE_GLOBAL_LOG
+    // Enable log again
+    dont_log = false;
+#endif
 }
 
 void starting_letter__subDraw(byte selection, byte line) {

--- a/Cart_Reader/Config.h
+++ b/Cart_Reader/Config.h
@@ -29,7 +29,7 @@
     Choose your hardware version:
 */
 
-//#define HW5
+#define HW5
 //#define HW4
 //#define HW3
 //#define HW2
@@ -71,56 +71,56 @@
 /* [ Atari 2600 --------------------------------------------------- ]
 */
 
-//#define ENABLE_2600
+#define ENABLE_2600
 
 /****/
 
 /* [ Atari 5200 --------------------------------------------------- ]
 */
 
-//#define ENABLE_5200
+// #define ENABLE_5200
 
 /****/
 
 /* [ Atari 7800 --------------------------------------------------- ]
 */
 
-//#define ENABLE_7800
+#define ENABLE_7800
 
 /****/
 
 /* [ Benesse Pocket Challenge W ----------------------------------- ]
 */
 
-//#define ENABLE_PCW
+// #define ENABLE_PCW
 
 /****/
 
 /* [ C64 --------------------------------------------------- ]
 */
 
-//#define ENABLE_C64
+#define ENABLE_C64
 
 /****/
 
 /* [ ColecoVision ------------------------------------------------- ]
 */
 
-//#define ENABLE_COLV
+#define ENABLE_COLV
 
 /****/
 
 /* [ Emerson Arcadia 2001 ----------------------------------------- ]
 */
 
-//#define ENABLE_ARC
+// #define ENABLE_ARC
 
 /****/
 
 /* [ Fairchild Channel F ------------------------------------------ ]
 */
 
-//#define ENABLE_FAIRCHILD
+// #define ENABLE_FAIRCHILD
 
 /****/
 
@@ -142,21 +142,21 @@
 /* [ Intellivision ------------------------------------------------ ]
 */
 
-//#define ENABLE_INTV
+// #define ENABLE_INTV
 
 /****/
 
 /* [ Neo Geo Pocket ----------------------------------------------- ]
 */
 
-//#define ENABLE_NGP
+// #define ENABLE_NGP
 
 /****/
 
 /* [ Nintendo 64 -------------------------------------------------- ]
 */
 
-#define ENABLE_N64
+// #define ENABLE_N64
 
 /****/
 
@@ -170,28 +170,28 @@
 /* [ Magnavox Odyssey 2 ------------------------------------------- ]
 */
 
-//#define ENABLE_ODY2
+#define ENABLE_ODY2
 
 /****/
 
 /* [ MSX ------------------------------------------- ]
 */
 
-//#define ENABLE_MSX
+#define ENABLE_MSX
 
 /****/
 
 /* [ PC Engine/TurboGrafx 16 -------------------------------------- ]
 */
 
-//#define ENABLE_PCE
+#define ENABLE_PCE
 
 /****/
 
 /* [ Pokemon Mini -------------------------------------- ]
 */
 
-//#define ENABLE_POKE
+#define ENABLE_POKE
 
 /****/
 
@@ -212,14 +212,14 @@
 /* [ Super Famicom SF Memory Cassette ----------------------------- ]
 */
 
-//#define ENABLE_SFM
+// #define ENABLE_SFM
 
 /****/
 
 /* [ Super Famicom Satellaview ------------------------------------ ]
 */
 
-//#define ENABLE_SV
+// #define ENABLE_SV
 
 /****/
 
@@ -233,7 +233,7 @@
 /* [ Super Famicom Game Processor RAM Cassette -------------------- ]
 */
 
-//#define ENABLE_GPC
+// #define ENABLE_GPC
 
 /****/
 
@@ -247,42 +247,42 @@
 /* [ Vectrex --------------------------------------------------- ]
 */
 
-//#define ENABLE_VECTREX
+#define ENABLE_VECTREX
 
 /****/
 
 /* [ Virtual Boy -------------------------------------------------- ]
 */
 
-//#define ENABLE_VBOY
+#define ENABLE_VBOY
 
 /****/
 
 /* [ Watara Supervision ------------------------------------------- ]
 */
 
-//#define ENABLE_WSV
+#define ENABLE_WSV
 
 /****/
 
 /* [ WonderSwan and Benesse Pocket Challenge v2 ------------------- ]
 */
 
-//#define ENABLE_WS
+#define ENABLE_WS
 
 /****/
 
 /* [ Super A'can -------------------------------------------------- ]
 */
 
-//#define ENABLE_SUPRACAN
+#define ENABLE_SUPRACAN
 
 /****/
 
 /* [ Casio Loopy -------------------------------------------------- ]
 */
 
-//#define ENABLE_LOOPY
+#define ENABLE_LOOPY
 
 /****/
 

--- a/Cart_Reader/Config.h
+++ b/Cart_Reader/Config.h
@@ -29,7 +29,7 @@
     Choose your hardware version:
 */
 
-#define HW5
+//#define HW5
 //#define HW4
 //#define HW3
 //#define HW2
@@ -71,56 +71,56 @@
 /* [ Atari 2600 --------------------------------------------------- ]
 */
 
-#define ENABLE_2600
+//#define ENABLE_2600
 
 /****/
 
 /* [ Atari 5200 --------------------------------------------------- ]
 */
 
-// #define ENABLE_5200
+//#define ENABLE_5200
 
 /****/
 
 /* [ Atari 7800 --------------------------------------------------- ]
 */
 
-#define ENABLE_7800
+//#define ENABLE_7800
 
 /****/
 
 /* [ Benesse Pocket Challenge W ----------------------------------- ]
 */
 
-// #define ENABLE_PCW
+//#define ENABLE_PCW
 
 /****/
 
 /* [ C64 --------------------------------------------------- ]
 */
 
-#define ENABLE_C64
+//#define ENABLE_C64
 
 /****/
 
 /* [ ColecoVision ------------------------------------------------- ]
 */
 
-#define ENABLE_COLV
+//#define ENABLE_COLV
 
 /****/
 
 /* [ Emerson Arcadia 2001 ----------------------------------------- ]
 */
 
-// #define ENABLE_ARC
+//#define ENABLE_ARC
 
 /****/
 
 /* [ Fairchild Channel F ------------------------------------------ ]
 */
 
-// #define ENABLE_FAIRCHILD
+//#define ENABLE_FAIRCHILD
 
 /****/
 
@@ -142,21 +142,21 @@
 /* [ Intellivision ------------------------------------------------ ]
 */
 
-// #define ENABLE_INTV
+#define ENABLE_INTV
 
 /****/
 
 /* [ Neo Geo Pocket ----------------------------------------------- ]
 */
 
-// #define ENABLE_NGP
+//#define ENABLE_NGP
 
 /****/
 
 /* [ Nintendo 64 -------------------------------------------------- ]
 */
 
-// #define ENABLE_N64
+#define ENABLE_N64
 
 /****/
 
@@ -170,35 +170,35 @@
 /* [ Magnavox Odyssey 2 ------------------------------------------- ]
 */
 
-#define ENABLE_ODY2
+//#define ENABLE_ODY2
 
 /****/
 
 /* [ MSX ------------------------------------------- ]
 */
 
-#define ENABLE_MSX
+//#define ENABLE_MSX
 
 /****/
 
 /* [ PC Engine/TurboGrafx 16 -------------------------------------- ]
 */
 
-#define ENABLE_PCE
+//#define ENABLE_PCE
 
 /****/
 
 /* [ Pokemon Mini -------------------------------------- ]
 */
 
-#define ENABLE_POKE
+//#define ENABLE_POKE
 
 /****/
 
 /* [ Sega Master System/Mark III/Game Gear/SG-1000 ---------------- ]
 */
 
-#define ENABLE_SMS
+//#define ENABLE_SMS
 
 /****/
 
@@ -212,28 +212,28 @@
 /* [ Super Famicom SF Memory Cassette ----------------------------- ]
 */
 
-// #define ENABLE_SFM
+//#define ENABLE_SFM
 
 /****/
 
 /* [ Super Famicom Satellaview ------------------------------------ ]
 */
 
-// #define ENABLE_SV
+//#define ENABLE_SV
 
 /****/
 
 /* [ Super Famicom Sufami Turbo ----------------------------------- ]
 */
 
-// #define ENABLE_ST
+//#define ENABLE_ST
 
 /****/
 
 /* [ Super Famicom Game Processor RAM Cassette -------------------- ]
 */
 
-// #define ENABLE_GPC
+//#define ENABLE_GPC
 
 /****/
 
@@ -247,42 +247,42 @@
 /* [ Vectrex --------------------------------------------------- ]
 */
 
-#define ENABLE_VECTREX
+//#define ENABLE_VECTREX
 
 /****/
 
 /* [ Virtual Boy -------------------------------------------------- ]
 */
 
-#define ENABLE_VBOY
+//#define ENABLE_VBOY
 
 /****/
 
 /* [ Watara Supervision ------------------------------------------- ]
 */
 
-#define ENABLE_WSV
+//#define ENABLE_WSV
 
 /****/
 
 /* [ WonderSwan and Benesse Pocket Challenge v2 ------------------- ]
 */
 
-#define ENABLE_WS
+//#define ENABLE_WS
 
 /****/
 
 /* [ Super A'can -------------------------------------------------- ]
 */
 
-#define ENABLE_SUPRACAN
+//#define ENABLE_SUPRACAN
 
 /****/
 
 /* [ Casio Loopy -------------------------------------------------- ]
 */
 
-#define ENABLE_LOOPY
+//#define ENABLE_LOOPY
 
 /****/
 

--- a/Cart_Reader/Config.h
+++ b/Cart_Reader/Config.h
@@ -142,7 +142,7 @@
 /* [ Intellivision ------------------------------------------------ ]
 */
 
-#define ENABLE_INTV
+//#define ENABLE_INTV
 
 /****/
 
@@ -198,7 +198,7 @@
 /* [ Sega Master System/Mark III/Game Gear/SG-1000 ---------------- ]
 */
 
-//#define ENABLE_SMS
+#define ENABLE_SMS
 
 /****/
 

--- a/Cart_Reader/INTV.ino
+++ b/Cart_Reader/INTV.ino
@@ -770,24 +770,7 @@ void setCart_INTV() {
 
   // Open database
   if (myFile.open("intv.txt", O_READ)) {
-    // Skip ahead to selected starting letter
-    if ((myLetter > 0) && (myLetter <= 26)) {
-      while (myFile.available()) {
-        // Read current name
-        get_line(gamename, &myFile, 96);
-
-        // Compare selected letter with first letter of current name until match
-        while (gamename[0] != 64 + myLetter) {
-          skip_line(&myFile);
-          skip_line(&myFile);
-          get_line(gamename, &myFile, 96);
-        }
-        break;
-      }
-
-      // Rewind one line
-      rewind_line(myFile);
-    }
+    seek_first_letter_in_database(myFile, myLetter);
 
     // Display database
     while (myFile.available()) {

--- a/Cart_Reader/NES.ino
+++ b/Cart_Reader/NES.ino
@@ -755,7 +755,7 @@ static void readDatabaseEntry(FsFile& database, struct database_entry* entry) {
 
 bool selectMapping(FsFile& database) {
   // Select starting letter
-  uint8_t myLetter = starting_letter();
+  byte myLetter = starting_letter();
 
   if (myLetter == 27) {
     // Change Mapper
@@ -766,26 +766,7 @@ bool selectMapping(FsFile& database) {
     setRAMSize();
     return 0;
   } else {
-#ifdef ENABLE_GLOBAL_LOG
-    // Disable log to prevent unnecessary logging
-    println_Log(F("Select Mapping from List"));
-    dont_log = true;
-#endif
-    database.rewind();
-    // Skip ahead to selected starting letter
-    if ((myLetter > 0) && (myLetter <= 26)) {
-      myLetter += 'A' - 1;
-      struct database_entry entry;
-      // Read current name
-      do {
-        readDatabaseEntry(database, &entry);
-      } while (database.available() && entry.filename[0] != myLetter);
-      rewind_line(database, 3);
-    }
-#ifdef ENABLE_GLOBAL_LOG
-    // Enable log again
-    dont_log = false;
-#endif
+    seek_first_letter_in_database(database, myLetter);
   }
   return 1;
 }

--- a/Cart_Reader/WSV.ino
+++ b/Cart_Reader/WSV.ino
@@ -391,24 +391,7 @@ void setCart_WSV() {
 
   // Open database
   if (myFile.open("wsv.txt", O_READ)) {
-    // Skip ahead to selected starting letter
-    if ((myLetter > 0) && (myLetter <= 26)) {
-      while (myFile.available()) {
-        // Read current name
-        get_line(gamename, &myFile, 96);
-
-        // Compare selected letter with first letter of current name until match
-        while (gamename[0] != 64 + myLetter) {
-          skip_line(&myFile);
-          skip_line(&myFile);
-          get_line(gamename, &myFile, 96);
-        }
-        break;
-      }
-
-      // Rewind one line
-      rewind_line(myFile);
-    }
+    seek_first_letter_in_database(myFile, myLetter);
 
     // Display database
     while (myFile.available()) {


### PR DESCRIPTION
* moved the GB code to Cart_Reader.ino
* replaced the nearly identical functions in WSV, COLV and INTV
* little change of function to only read one letter (instead of reading 100-128 bytes fix than moving backwards) couldn't see any significant speed changes - but keeps the functions memory footprint smaller

Some remarks:
* getline "maxi" parameter seems odd. It reads number - 1. Thus 2 has to be passed to read one byte. I think this is not max but buffer size. The parameter name is irritating.
* It would be nice to change the code to stop if a letter >= is found. So for example if COLV _X_ is searched it stops at _Yolk's on you, The (Europe) (Proto).col_. But currently NES first entry should be placed at the end of the file due to "[" > "Z" if this is changed, it would require a modified if-statement.
* The code currently does not handle lower case  letters. Could be improved. Afaik currently no database entry exists starting with lower case