### PR TITLE
replace cart selection code of A7800 with one used at NES, COLV, INTV, WSV

### DIFF
--- a/Cart_Reader/7800.ino
+++ b/Cart_Reader/7800.ino
@@ -70,9 +70,7 @@ byte a7800[] = { 16, 32, 48, 64, 128, 144 };
 byte a7800lo = 0;  // Lowest Entry
 byte a7800hi = 5;  // Highest Entry
 byte a7800mapper = 0;
-byte new7800mapper;
 byte a7800size;
-byte new7800size;
 
 // EEPROM MAPPING
 // 07 MAPPER
@@ -159,7 +157,6 @@ void a7800Menu() {
     case 0:
       // Select Cart
       setCart_7800();
-      wait();
       setup_7800();
       break;
 
@@ -507,6 +504,7 @@ void println_Mapper7800(byte mapper) {
 #endif
 
 void setROMSize_7800() {
+  byte new7800size;
 #if (defined(ENABLE_OLED) || defined(ENABLE_LCD))
   display_Clear();
   if (a7800lo == a7800hi)
@@ -691,6 +689,7 @@ void displayMapperSelect_7800(int index, boolean printInstructions) {
 #endif
 
 void setMapper_7800() {
+  byte new7800mapper = 0;
 #if (defined(ENABLE_OLED) || defined(ENABLE_LCD))
   uint8_t b = 0;
   int i = 0;
@@ -782,222 +781,6 @@ setmapper:
 //******************************************
 // CART SELECT CODE
 //******************************************
-
-FsFile a7800csvFile;
-char a7800game[36];                    // title
-char a7800mm[3];                       // mapper
-char a7800rr[3];                       // mapper
-char a7800ll[4];                       // linelength (previous line)
-unsigned long a7800csvpos;             // CSV File Position
-char a7800cartCSV[] = "7800.txt";      // CSV List
-char a7800csvEND[] = "EOF";            // CSV End Marker for scrolling
-
-bool readLine_7800(FsFile& f, char* line, size_t maxLen) {
-  for (size_t n = 0; n < maxLen; n++) {
-    int c = f.read();
-    if (c < 0 && n == 0) return false;  // EOF
-    if (c < 0 || c == '\n') {
-      line[n] = 0;
-      return true;
-    }
-    line[n] = c;
-  }
-  return false;  // line too long
-}
-
-bool readVals_7800(char* a7800game, char* a7800mm, char* a7800rr, char* a7800ll) {
-  char line[44];
-  a7800csvpos = a7800csvFile.position();
-  if (!readLine_7800(a7800csvFile, line, sizeof(line))) {
-    return false;  // EOF or too long
-  }
-  char* comma = strtok(line, ",");
-  int x = 0;
-  while (comma != NULL) {
-    if (x == 0)
-      strcpy(a7800game, comma);
-    else if (x == 1)
-      strcpy(a7800mm, comma);
-    else if (x == 2)
-      strcpy(a7800rr, comma);
-    else if (x == 3)
-      strcpy(a7800ll, comma);
-    comma = strtok(NULL, ",");
-    x += 1;
-  }
-  return true;
-}
-
-bool getCartListInfo_7800() {
-  bool buttonreleased = 0;
-  bool cartselected = 0;
-#if (defined(ENABLE_OLED) || defined(ENABLE_LCD))
-  display_Clear();
-  println_Msg(F(" HOLD TO FAST CYCLE"));
-  display_Update();
-#else
-  Serial.println(F("HOLD BUTTON TO FAST CYCLE"));
-#endif
-  delay(2000);
-#if defined(ENABLE_OLED)
-  buttonVal1 = (PIND & (1 << 7));  // PD7
-#elif defined(ENABLE_LCD)
-  boolean buttonVal1 = (PING & (1 << 2));  //PG2
-#endif
-  if (buttonVal1 == LOW) {         // Button Held - Fast Cycle
-    while (1) {                    // Scroll Game List
-      while (readVals_7800(a7800game, a7800mm, a7800rr, a7800ll)) {
-        if (strcmp(a7800csvEND, a7800game) == 0) {
-          a7800csvFile.seek(0);  // Restart
-        } else {
-#if (defined(ENABLE_OLED) || defined(ENABLE_LCD))
-          display_Clear();
-          println_Msg(F("CART TITLE:"));
-          println_Msg(FS(FSTRING_EMPTY));
-          println_Msg(a7800game);
-          display_Update();
-#else
-          Serial.print(F("CART TITLE:"));
-          Serial.println(a7800game);
-#endif
-#if defined(ENABLE_OLED)
-          buttonVal1 = (PIND & (1 << 7));  // PD7
-#elif defined(ENABLE_LCD)
-          boolean buttonVal1 = (PING & (1 << 2));  //PG2
-#endif
-          if (buttonVal1 == HIGH) {        // Button Released
-            buttonreleased = 1;
-            break;
-          }
-          if (buttonreleased) {
-            buttonreleased = 0;  // Reset Flag
-            break;
-          }
-        }
-      }
-#if defined(ENABLE_OLED)
-      buttonVal1 = (PIND & (1 << 7));  // PD7
-#elif defined(ENABLE_LCD)
-      boolean buttonVal1 = (PING & (1 << 2));  //PG2
-#endif
-      if (buttonVal1 == HIGH)          // Button Released
-        break;
-    }
-  }
-#if (defined(ENABLE_OLED) || defined(ENABLE_LCD))
-  display.setCursor(0, 56);
-  println_Msg(F("FAST CYCLE OFF"));
-  display_Update();
-#else
-  Serial.println(FS(FSTRING_EMPTY));
-  Serial.println(F("FAST CYCLE OFF"));
-  Serial.println(F("PRESS BUTTON TO STEP FORWARD"));
-  Serial.println(F("DOUBLE CLICK TO STEP BACK"));
-  Serial.println(F("HOLD TO SELECT"));
-  Serial.println(FS(FSTRING_EMPTY));
-#endif
-  while (readVals_7800(a7800game, a7800mm, a7800rr, a7800ll)) {
-    if (strcmp(a7800csvEND, a7800game) == 0) {
-      a7800csvFile.seek(0);  // Restart
-    } else {
-#if (defined(ENABLE_OLED) || defined(ENABLE_LCD))
-      display_Clear();
-      println_Msg(F("CART TITLE:"));
-      println_Msg(FS(FSTRING_EMPTY));
-      println_Msg(a7800game);
-      display.setCursor(0, 48);
-#if defined(ENABLE_OLED)
-      print_STR(press_to_change_STR, 1);
-      print_STR(right_to_select_STR, 1);
-#elif defined(ENABLE_LCD)
-      print_STR(rotate_to_change_STR, 1);
-      print_STR(press_to_select_STR, 1);
-#endif
-      display_Update();
-#else
-      Serial.print(F("CART TITLE:"));
-      Serial.println(a7800game);
-#endif
-      while (1) {  // Single Step
-        uint8_t b = checkButton();
-        if (b == 1) {  // Continue (press)
-          break;
-        }
-        if (b == 2) {  // Reset to Start of List (doubleclick)
-          byte prevline = strtol(a7800ll, NULL, 10);
-          a7800csvpos -= prevline;
-          a7800csvFile.seek(a7800csvpos);
-          break;
-        }
-        if (b == 3) {  // Long Press - Select Cart (hold)
-          new7800mapper = strtol(a7800mm, NULL, 10);
-          new7800size = strtol(a7800rr, NULL, 10);
-          EEPROM_writeAnything(7, new7800mapper);
-          EEPROM_writeAnything(8, new7800size);
-          cartselected = 1;  // SELECTION MADE
-#if (defined(ENABLE_OLED) || defined(ENABLE_LCD))
-          println_Msg(F("SELECTION MADE"));
-          display_Update();
-#else
-          Serial.println(F("SELECTION MADE"));
-#endif
-          break;
-        }
-      }
-      if (cartselected) {
-        cartselected = 0;  // Reset Flag
-        return true;
-      }
-    }
-  }
-#if (defined(ENABLE_OLED) || defined(ENABLE_LCD))
-  println_Msg(FS(FSTRING_EMPTY));
-  println_Msg(FS(FSTRING_END_OF_FILE));
-  display_Update();
-#else
-  Serial.println(FS(FSTRING_END_OF_FILE));
-#endif
-
-  return false;
-}
-
-void checkCSV_7800() {
-  if (getCartListInfo_7800()) {
-#if (defined(ENABLE_OLED) || defined(ENABLE_LCD))
-    display_Clear();
-    println_Msg(FS(FSTRING_CART_SELECTED));
-    println_Msg(FS(FSTRING_EMPTY));
-    println_Msg(a7800game);
-    display_Update();
-    // Display Settings
-    display.setCursor(0, 56);
-    print_Msg(F("CODE: M"));
-    print_Msg(new7800mapper);
-    print_Msg(F("/R"));
-    println_Msg(new7800size);
-    display_Update();
-#else
-    Serial.println(FS(FSTRING_EMPTY));
-    Serial.println(FS(FSTRING_CART_SELECTED));
-    Serial.println(a7800game);
-    // Display Settings
-    Serial.print(F("CODE: M"));
-    Serial.print(new7800mapper);
-    Serial.print(F("/R"));
-    Serial.println(new7800size);
-    Serial.println(FS(FSTRING_EMPTY));
-#endif
-  } else {
-#if (defined(ENABLE_OLED) || defined(ENABLE_LCD))
-    display.setCursor(0, 56);
-    println_Msg(FS(FSTRING_NO_SELECTION));
-    display_Update();
-#else
-    Serial.println(FS(FSTRING_NO_SELECTION));
-#endif
-  }
-}
-
 void checkSize_7800() {
   EEPROM_readAnything(7, a7800mapper);
   for (int i = 0; i < a7800mapcount; i++) {
@@ -1011,29 +794,83 @@ void checkSize_7800() {
 }
 
 void setCart_7800() {
-#if (defined(ENABLE_OLED) || defined(ENABLE_LCD))
-  display_Clear();
-  println_Msg(a7800cartCSV);
-  display_Update();
-#endif
+  //go to root
   sd.chdir();
-  sprintf(folder, "7800/CSV");
-  sd.chdir(folder);  // Switch Folder
-  a7800csvFile = sd.open(a7800cartCSV, O_READ);
-  if (!a7800csvFile) {
-#if (defined(ENABLE_OLED) || defined(ENABLE_LCD))
-    display_Clear();
-    println_Msg(F("CSV FILE NOT FOUND!"));
-    display_Update();
-#else
-    Serial.println(F("CSV FILE NOT FOUND!"));
+
+  char gamename[100];
+  byte gameMapper;
+  byte gameSize;
+
+  // Select starting letter
+  byte myLetter = starting_letter();
+
+  // Open database
+  if (myFile.open("7800.txt", O_READ)) {
+    seek_first_letter_in_database(myFile, myLetter);
+
+    // Display database
+    while (myFile.available()) {
+      display_Clear();
+
+      get_line(gamename, &myFile, sizeof(gamename));   
+
+      // Read mapper
+      gameMapper = myFile.read() - 48;
+
+      // Skip over semicolon
+      myFile.seekCur(1);
+
+      // Read rom size
+      gameSize = myFile.read() - 48;
+
+      // Skip rest of line
+      myFile.seekCur(2);
+
+      skip_line(&myFile); 
+
+      println_Msg(F("Select your cartridge"));
+      println_Msg(FS(FSTRING_EMPTY));
+      println_Msg(gamename);
+
+#if defined(ENABLE_OLED)
+      print_STR(press_to_change_STR, 1);
+      print_STR(right_to_select_STR, 1);
+#elif defined(ENABLE_LCD)
+      print_STR(rotate_to_change_STR, 1);
+      print_STR(press_to_select_STR, 1);
+#elif defined(SERIAL_MONITOR)
+      println_Msg(F("U/D to Change"));
+      println_Msg(F("Space to Select"));
 #endif
-    while (1) {
-      if (checkButton() != 0)
-        setup_7800();
+      display_Update();
+
+      uint8_t b = 0;
+      while (1) {
+        // Check button input
+        b = checkButton();
+
+        // Next
+        if (b == 1) {
+          break;
+        }
+
+        // Previous
+        else if (b == 2) {
+          rewind_line(myFile, 6);
+          break;
+        }
+
+        // Selection
+        else if (b == 3) {
+          EEPROM_writeAnything(7, gameMapper);
+          EEPROM_writeAnything(8, gameSize);
+          myFile.close();
+          break;
+        }
+      }
     }
+  } else {
+    print_FatalError(F("Database file not found"));
   }
-  checkCSV_7800();
-  a7800csvFile.close();
 }
 #endif

--- a/Cart_Reader/COLV.ino
+++ b/Cart_Reader/COLV.ino
@@ -377,24 +377,7 @@ void setCart_COL() {
 
   // Open database
   if (myFile.open("colv.txt", O_READ)) {
-    // Skip ahead to selected starting letter
-    if ((myLetter > 0) && (myLetter <= 26)) {
-      while (myFile.available()) {
-        // Read current name
-        get_line(gamename, &myFile, 96);
-
-        // Compare selected letter with first letter of current name until match
-        while (gamename[0] != 64 + myLetter) {
-          skip_line(&myFile);
-          skip_line(&myFile);
-          get_line(gamename, &myFile, 96);
-        }
-        break;
-      }
-
-      // Rewind one line
-      rewind_line(myFile);
-    }
+    seek_first_letter_in_database(myFile, myLetter);
 
     // Display database
     while (myFile.available()) {

--- a/Cart_Reader/Cart_Reader.ino
+++ b/Cart_Reader/Cart_Reader.ino
@@ -660,7 +660,7 @@ boolean compareCRC(const char* database, uint32_t crc32sum, boolean renamerom, i
             myFile.close();
           }
         } else {
-          println_Msg("OK");
+          println_Msg(FS(FSTRING_OK));
         }
         return 1;
         break;
@@ -676,6 +676,35 @@ boolean compareCRC(const char* database, uint32_t crc32sum, boolean renamerom, i
     return 0;
   }
   return 0;
+}
+
+// move file pointer to first game line with matching letter. If no match is found the last database entry is selected
+void seek_first_letter_in_database(FsFile& database, byte myLetter) {
+    char gamename_str[3];
+#ifdef ENABLE_GLOBAL_LOG
+    // Disable log to prevent unnecessary logging
+    println_Log(F("Select Mapping from List"));
+    dont_log = true;
+#endif
+    database.rewind();
+    // Skip ahead to selected starting letter
+    if ((myLetter > 0) && (myLetter <= 26)) {
+      myLetter += 'A' - 1;
+      do {
+        // Read current name
+        get_line(gamename_str, &database, 2);
+        // Skip data line
+        skip_line(&database);
+        // Skip empty line
+        skip_line(&database);
+
+      } while (database.available() && gamename_str[0] != myLetter);
+      rewind_line(database, 3);
+    }
+#ifdef ENABLE_GLOBAL_LOG
+    // Enable log again
+    dont_log = false;
+#endif
 }
 
 void starting_letter__subDraw(byte selection, byte line) {

--- a/Cart_Reader/Config.h
+++ b/Cart_Reader/Config.h
@@ -29,7 +29,7 @@
     Choose your hardware version:
 */
 
-//#define HW5
+#define HW5
 //#define HW4
 //#define HW3
 //#define HW2
@@ -71,56 +71,56 @@
 /* [ Atari 2600 --------------------------------------------------- ]
 */
 
-//#define ENABLE_2600
+#define ENABLE_2600
 
 /****/
 
 /* [ Atari 5200 --------------------------------------------------- ]
 */
 
-//#define ENABLE_5200
+// #define ENABLE_5200
 
 /****/
 
 /* [ Atari 7800 --------------------------------------------------- ]
 */
 
-//#define ENABLE_7800
+#define ENABLE_7800
 
 /****/
 
 /* [ Benesse Pocket Challenge W ----------------------------------- ]
 */
 
-//#define ENABLE_PCW
+// #define ENABLE_PCW
 
 /****/
 
 /* [ C64 --------------------------------------------------- ]
 */
 
-//#define ENABLE_C64
+#define ENABLE_C64
 
 /****/
 
 /* [ ColecoVision ------------------------------------------------- ]
 */
 
-//#define ENABLE_COLV
+#define ENABLE_COLV
 
 /****/
 
 /* [ Emerson Arcadia 2001 ----------------------------------------- ]
 */
 
-//#define ENABLE_ARC
+// #define ENABLE_ARC
 
 /****/
 
 /* [ Fairchild Channel F ------------------------------------------ ]
 */
 
-//#define ENABLE_FAIRCHILD
+// #define ENABLE_FAIRCHILD
 
 /****/
 
@@ -142,21 +142,21 @@
 /* [ Intellivision ------------------------------------------------ ]
 */
 
-//#define ENABLE_INTV
+// #define ENABLE_INTV
 
 /****/
 
 /* [ Neo Geo Pocket ----------------------------------------------- ]
 */
 
-//#define ENABLE_NGP
+// #define ENABLE_NGP
 
 /****/
 
 /* [ Nintendo 64 -------------------------------------------------- ]
 */
 
-#define ENABLE_N64
+// #define ENABLE_N64
 
 /****/
 
@@ -170,28 +170,28 @@
 /* [ Magnavox Odyssey 2 ------------------------------------------- ]
 */
 
-//#define ENABLE_ODY2
+#define ENABLE_ODY2
 
 /****/
 
 /* [ MSX ------------------------------------------- ]
 */
 
-//#define ENABLE_MSX
+#define ENABLE_MSX
 
 /****/
 
 /* [ PC Engine/TurboGrafx 16 -------------------------------------- ]
 */
 
-//#define ENABLE_PCE
+#define ENABLE_PCE
 
 /****/
 
 /* [ Pokemon Mini -------------------------------------- ]
 */
 
-//#define ENABLE_POKE
+#define ENABLE_POKE
 
 /****/
 
@@ -212,14 +212,14 @@
 /* [ Super Famicom SF Memory Cassette ----------------------------- ]
 */
 
-//#define ENABLE_SFM
+// #define ENABLE_SFM
 
 /****/
 
 /* [ Super Famicom Satellaview ------------------------------------ ]
 */
 
-//#define ENABLE_SV
+// #define ENABLE_SV
 
 /****/
 
@@ -233,7 +233,7 @@
 /* [ Super Famicom Game Processor RAM Cassette -------------------- ]
 */
 
-//#define ENABLE_GPC
+// #define ENABLE_GPC
 
 /****/
 
@@ -247,42 +247,42 @@
 /* [ Vectrex --------------------------------------------------- ]
 */
 
-//#define ENABLE_VECTREX
+#define ENABLE_VECTREX
 
 /****/
 
 /* [ Virtual Boy -------------------------------------------------- ]
 */
 
-//#define ENABLE_VBOY
+#define ENABLE_VBOY
 
 /****/
 
 /* [ Watara Supervision ------------------------------------------- ]
 */
 
-//#define ENABLE_WSV
+#define ENABLE_WSV
 
 /****/
 
 /* [ WonderSwan and Benesse Pocket Challenge v2 ------------------- ]
 */
 
-//#define ENABLE_WS
+#define ENABLE_WS
 
 /****/
 
 /* [ Super A'can -------------------------------------------------- ]
 */
 
-//#define ENABLE_SUPRACAN
+#define ENABLE_SUPRACAN
 
 /****/
 
 /* [ Casio Loopy -------------------------------------------------- ]
 */
 
-//#define ENABLE_LOOPY
+#define ENABLE_LOOPY
 
 /****/
 

--- a/Cart_Reader/INTV.ino
+++ b/Cart_Reader/INTV.ino
@@ -770,24 +770,7 @@ void setCart_INTV() {
 
   // Open database
   if (myFile.open("intv.txt", O_READ)) {
-    // Skip ahead to selected starting letter
-    if ((myLetter > 0) && (myLetter <= 26)) {
-      while (myFile.available()) {
-        // Read current name
-        get_line(gamename, &myFile, 96);
-
-        // Compare selected letter with first letter of current name until match
-        while (gamename[0] != 64 + myLetter) {
-          skip_line(&myFile);
-          skip_line(&myFile);
-          get_line(gamename, &myFile, 96);
-        }
-        break;
-      }
-
-      // Rewind one line
-      rewind_line(myFile);
-    }
+    seek_first_letter_in_database(myFile, myLetter);
 
     // Display database
     while (myFile.available()) {

--- a/Cart_Reader/NES.ino
+++ b/Cart_Reader/NES.ino
@@ -755,7 +755,7 @@ static void readDatabaseEntry(FsFile& database, struct database_entry* entry) {
 
 bool selectMapping(FsFile& database) {
   // Select starting letter
-  uint8_t myLetter = starting_letter();
+  byte myLetter = starting_letter();
 
   if (myLetter == 27) {
     // Change Mapper
@@ -766,26 +766,7 @@ bool selectMapping(FsFile& database) {
     setRAMSize();
     return 0;
   } else {
-#ifdef ENABLE_GLOBAL_LOG
-    // Disable log to prevent unnecessary logging
-    println_Log(F("Select Mapping from List"));
-    dont_log = true;
-#endif
-    database.rewind();
-    // Skip ahead to selected starting letter
-    if ((myLetter > 0) && (myLetter <= 26)) {
-      myLetter += 'A' - 1;
-      struct database_entry entry;
-      // Read current name
-      do {
-        readDatabaseEntry(database, &entry);
-      } while (database.available() && entry.filename[0] != myLetter);
-      rewind_line(database, 3);
-    }
-#ifdef ENABLE_GLOBAL_LOG
-    // Enable log again
-    dont_log = false;
-#endif
+    seek_first_letter_in_database(database, myLetter);
   }
   return 1;
 }

--- a/Cart_Reader/WSV.ino
+++ b/Cart_Reader/WSV.ino
@@ -391,24 +391,7 @@ void setCart_WSV() {
 
   // Open database
   if (myFile.open("wsv.txt", O_READ)) {
-    // Skip ahead to selected starting letter
-    if ((myLetter > 0) && (myLetter <= 26)) {
-      while (myFile.available()) {
-        // Read current name
-        get_line(gamename, &myFile, 96);
-
-        // Compare selected letter with first letter of current name until match
-        while (gamename[0] != 64 + myLetter) {
-          skip_line(&myFile);
-          skip_line(&myFile);
-          get_line(gamename, &myFile, 96);
-        }
-        break;
-      }
-
-      // Rewind one line
-      rewind_line(myFile);
-    }
+    seek_first_letter_in_database(myFile, myLetter);
 
     // Display database
     while (myFile.available()) {

--- a/sd/7800.txt
+++ b/sd/7800.txt
@@ -1,71 +1,210 @@
-32 in 1,0,3,0
-Ace of Aces,1,4,15
-Alien Brigade,2,5,20
-Asteroids,0,0,22
-Atari 7800 Development Card,0,0,18
-Ballblazer,0,1,36
-Barnyard Blaster,1,4,19
-Baseball,0,1,25
-Basketbrawl,1,4,17
-Centipede,0,0,20
-Choplifter! (Europe),0,2,18
-Choplifter! (USA),0,1,29
-Commando,1,4,26
-Crack'ed,1,4,17
-Crossbow,2,5,17
-Dark Chambers,1,4,17
-Desert Falcon,0,2,22
-Diagnostic Test Cartridge,0,1,22
-Dig Dug (Europe),0,1,34
-Dig Dug (USA),0,0,25
-Donkey Kong,0,2,22
-Donkey Kong Junior,0,2,20
-Double Dragon,4,4,27
-F-18 Hornet,3,3,22
-Fatal Run,1,4,20
-Fight Night,1,4,18
-Food Fight (Europe),0,2,20
-Food Fight (USA),0,1,28
-Galaga (Europe),0,2,25
-Galaga (USA),0,1,24
-Hat Trick,0,2,21
-Ikari Warriors,1,4,18
-Impossible Mission,1,4,23
-Jinks,1,4,27
-Joust (Europe),0,2,14
-Joust (USA),0,1,23
-Karateka (Europe),6,3,20
-Karateka (USA),0,2,26
-Kung-Fu Master,0,1,23
-Mario Bros.,0,2,23
-Mat Mania Challenge,1,4,20
-Mean 18 Ultimate Golf,1,4,28
-Meltdown,1,4,30
-Midnight Mutants,1,4,17
-Motor Psycho,1,4,25
-Ms. Pac-Man (Europe),0,1,21
-Ms. Pac-Man (USA),0,0,29
-Ninja Golf,1,4,26
-One-on-One Basketball,0,2,19
-Pete Rose Baseball,0,1,30
-Planet Smashers,1,4,27
-Pole Position II,0,1,24
-Rampage,4,4,25
-RealSports Baseball,5,3,16
-Robotron 2084,0,1,28
-Scrapyard Dog,1,4,22
-Sentinel,1,4,22
-Summer Games,1,4,17
-Super Huey UH-IX,0,2,21
-Super Skateboardin',0,1,25
-Tank Command,5,3,28
-Title Match Pro Wrestling,0,1,21
-Tomcat,0,1,34
-Touchdown Football,1,4,15
-Tower Toppler,5,3,27
-Water Ski,5,3,22
-Winter Games,1,4,18
-Xenophobe,1,4,21
-Xevious (Europe),0,2,18
-Xevious (USA),0,1,25
-EOF,0,0,0
+32 in 1
+0,3
+
+Ace of Aces
+1,4
+
+Alien Brigade
+2,5
+
+Asteroids
+0,0
+
+Atari 7800 Development Card
+0,0
+
+Ballblazer
+0,1
+
+Barnyard Blaster
+1,4
+
+Baseball
+0,1
+
+Basketbrawl
+1,4
+
+Centipede
+0,0
+
+Choplifter! (Europe)
+0,2
+
+Choplifter! (USA)
+0,1
+
+Commando
+1,4
+
+Crack'ed
+1,4
+
+Crossbow
+2,5
+
+Dark Chambers
+1,4
+
+Desert Falcon
+0,2
+
+Diagnostic Test Cartridge
+0,1
+
+Dig Dug (Europe)
+0,1
+
+Dig Dug (USA)
+0,0
+
+Donkey Kong
+0,2
+
+Donkey Kong Junior
+0,2
+
+Double Dragon
+4,4
+
+F-18 Hornet
+3,3
+
+Fatal Run
+1,4
+
+Fight Night
+1,4
+
+Food Fight (Europe)
+0,2
+
+Food Fight (USA)
+0,1
+
+Galaga (Europe)
+0,2
+
+Galaga (USA)
+0,1
+
+Hat Trick
+0,2
+
+Ikari Warriors
+1,4
+
+Impossible Mission
+1,4
+
+Jinks
+1,4
+
+Joust (Europe)
+0,2
+
+Joust (USA)
+0,1
+
+Karateka (Europe)
+6,3
+
+Karateka (USA)
+0,2
+
+Kung-Fu Master
+0,1
+
+Mario Bros.
+0,2
+
+Mat Mania Challenge
+1,4
+
+Mean 18 Ultimate Golf
+1,4
+
+Meltdown
+1,4
+
+Midnight Mutants
+1,4
+
+Motor Psycho
+1,4
+
+Ms. Pac-Man (Europe)
+0,1
+
+Ms. Pac-Man (USA)
+0,0
+
+Ninja Golf
+1,4
+
+One-on-One Basketball
+0,2
+
+Pete Rose Baseball
+0,1
+
+Planet Smashers
+1,4
+
+Pole Position II
+0,1
+
+Rampage
+4,4
+
+RealSports Baseball
+5,3
+
+Robotron 2084
+0,1
+
+Scrapyard Dog
+1,4
+
+Sentinel
+1,4
+
+Summer Games
+1,4
+
+Super Huey UH-IX
+0,2
+
+Super Skateboardin'
+0,1
+
+Tank Command
+5,3
+
+Title Match Pro Wrestling
+0,1
+
+Tomcat
+0,1
+
+Touchdown Football
+1,4
+
+Tower Toppler
+5,3
+
+Water Ski
+5,3
+
+Winter Games
+1,4
+
+Xenophobe
+1,4
+
+Xevious (Europe)
+0,2
+
+Xevious (USA)
+0,1
+


### PR DESCRIPTION
please review https://github.com/sanni/cartreader/pull/934 first. This one extends on this change.


This pull requests replaces the cart selection code of 7800 with the afaik more user friendly code of NES, COLV, INTV & WSV. Plus due to the code similarities the used space of the program is reduced in my configuration from
243718 to 242794 Bytes

Downside the cart database structure for the 7800 must be changed. If some user only update the firmware without the SD card - cart selection does not work until SD card is updated.

If this is ok - I would like to change 2600 and C64 as well.
