### PR TITLE
Adds support for flashing reproduction HuCards

### DIFF
--- a/Cart_Reader/Config.h
+++ b/Cart_Reader/Config.h
@@ -124,7 +124,7 @@
 
 /****/
 
-/* [ Flashrom Programmer for SNES repros -------------------------- ]
+/* [ Flashrom Programmer for repro carts -------------------------- ]
 */
 
 #define ENABLE_FLASH

--- a/Cart_Reader/OSCR.h
+++ b/Cart_Reader/OSCR.h
@@ -124,9 +124,7 @@ enum CORES: uint8_t {
 # endif
 # ifdef ENABLE_SFM
   CORE_SFM,
-#   ifdef ENABLE_FLASH
   CORE_SFM_FLASH,
-#   endif
   CORE_SFM_GAME,
 # endif
 # ifdef ENABLE_GBX

--- a/Cart_Reader/OSCR.h
+++ b/Cart_Reader/OSCR.h
@@ -124,7 +124,9 @@ enum CORES: uint8_t {
 # endif
 # ifdef ENABLE_SFM
   CORE_SFM,
+#   ifdef ENABLE_FLASH
   CORE_SFM_FLASH,
+#   endif
   CORE_SFM_GAME,
 # endif
 # ifdef ENABLE_GBX

--- a/Cart_Reader/PCE.ino
+++ b/Cart_Reader/PCE.ino
@@ -2,7 +2,7 @@
 // PC Engine & TurboGrafx dump code by tamanegi_taro
 // April 18th 2018 Revision 1.0.1 Initial version
 // August 12th 2019 Revision 1.0.2 Added Tennokoe Bank support
-// June 29th 2024 Revision 1.0.3 Added ichigobankai repro HuCard writing
+// June 29th 2024 Revision 1.0.3 Added repro HuCard flashing
 //
 // Special thanks
 // sanni - Arduino cart reader
@@ -858,6 +858,9 @@ void flash_wait_status_PCE(uint8_t expected) {
   // leave RD high on exit
 }
 
+// Flashes a reproduction HuCard that's directly wired to a flash chip
+// Supported flash: SST39SF0x0, MX29F0x0 1Mbit-8Mbit
+// Developed against Ichigobankai's design https://github.com/partlyhuman/HuCARD-repro
 void flash_PCE() {
   println_Msg(F("Detecting..."));
   display_Update();
@@ -882,11 +885,11 @@ void flash_PCE() {
   flashSize = 0;
   switch (deviceId) {
     case 0xBFB5:
-      // SST39SF010A = 1Mbit
+      // SST39SF010 = 1Mbit
       flashSize = 131072UL;
       break;
     case 0xBFB6:
-      // SST39SF020A = 2Mbit
+      // SST39SF020 = 2Mbit
       flashSize = 262144UL;
       break;
     case 0xBFB7:

--- a/Cart_Reader/SFM.ino
+++ b/Cart_Reader/SFM.ino
@@ -58,13 +58,18 @@ void sfmMenu() {
     case 0:
       sfmGameMenu();
       break;
+#ifdef CORE_SFM_FLASH
     // Flash menu
     case 1:
       mode = CORE_SFM_FLASH;
       break;
+#endif
     // Reset
     case 2:
       resetArduino();
+      break;
+    default:
+      print_MissingModule();
       break;
   }
 }


### PR DESCRIPTION
Adds support for reproduction HuCards that use SST39SF010, SST39SF020, SST39SF040, MX29F040, or MX29F080 flash chips. One such open-source design is by Ichigo: https://github.com/partlyhuman/HuCARD-repro. There may be others out there — I have only tested this with the linked one but would be willing to extend support to others as requested.

This can be disabled to save program space by removing flash repro support (`#undef ENABLE_FLASH`). Made every attempt to minimize additional program size (maximized string reuse).

Additionally, includes a fix for broken compilation when building SFC/SNES support without flash support.

Comments welcome.

![IMG_2690](https://github.com/sanni/cartreader/assets/327136/c6de6900-ab44-44d4-87ee-bf37f358c8a3)

https://github.com/sanni/cartreader/assets/327136/03192727-4a6f-49c4-8fd7-41e2f096d8de

