### PR TITLE
Adds flash cartridge support to Atari Lynx firmware

### DIFF
--- a/Cart_Reader/LOOPY.ino
+++ b/Cart_Reader/LOOPY.ino
@@ -55,7 +55,7 @@
 //
 // * Blank pins have various uses depending on cartridge but are not necessary for dumping.
 // IMPORTANT: All data are stored as BIG-ENDIAN. Many ROM dumps online are little endian.
-// See https://github.com/kasamikona/Loopy-Tools/blob/master/ROM%20Structure.md
+// See https://github.com/kasamikona/Loopy-Tools/blob/master/Documentation/ROM%20Structure.md
 //
 // By @partlyhuman
 // Special thanks to @kasamikona


### PR DESCRIPTION
Tested with [this 512KB Lynx flash cartridge from K-Retro](https://k-retro.com/atari-lynx-flashsd-carts/43-512k-flash-128b-eeprom-flash-cartridge-for-atari-lynx.html)
![512KB Lynx Flash Cartridge](https://github.com/user-attachments/assets/1cbbe92c-6dee-465a-8bfe-7c9f5e41a51e)

Written to support .lnx files with and without a header — i saw both variants when looking at existing sets.

Easy enough to expand to more chips, if there are other Lynx flash carts out there. Let me know if you know of any.
