### PR TITLE
GBM: Fix some comments and unused function

### DIFF
--- a/Cart_Reader/GBM.ino
+++ b/Cart_Reader/GBM.ino
@@ -403,13 +403,13 @@ void send_GBM(byte myCommand) {
       break;
 
     case 0x04:
-      //CMD_04h -> Map entire flashrom (MBC4 mode)
+      //CMD_04h -> Disable mapping; makes the entire flash and SRAM accessible
       writeByte_GBM(0x0120, 0x04);
       writeByte_GBM(0x013F, 0xA5);
       break;
 
     case 0x05:
-      //CMD_05h -> Map menu (MBC5 mode)
+      //CMD_05h -> Enable mapping; re-enables the mapping that was previously selected by 0xCn
       writeByte_GBM(0x0120, 0x05);
       writeByte_GBM(0x013F, 0xA5);
       break;
@@ -479,8 +479,14 @@ void switchGame_GBM(byte myData) {
   // Enable ports 0x0120 (F2)
   send_GBM(0x09);
 
+  // Enable mapping. Mapping must be enabled before the C0 cmd, otherwise switching has no effect.
+  send_GBM(0x05);
+
   //CMD_C0h -> map selected game without reset
-  writeByte_GBM(0x0120, 0xC0 & myData);
+  //           C0 is the menu or a single 1MB sized game
+  //           C1 is the first game entry
+  //           C2 is the second game entry...
+  writeByte_GBM(0x0120, 0xC0 | myData);
   writeByte_GBM(0x013F, 0xA5);
 }
 


### PR DESCRIPTION
These are just some changes in comments and in one unused function. It has no effect, but I would like to submit this for documentation purposes.

I played around with the NP GB Memory cartridge on a different hardware and your code helped me to be able to fully read and write the cartridge. But I figured out by testing that some of the comments are not correct. Especially the GBM command 0x05 does NOT map the menu. It re-enables the mapping that was selected previously. So, if the menu was selected before disabling the mapping with the 0x04 command, then the menu mapping will be re-enabled again when sending the 0x05 command. But if some other mapping was selected before (like with 0xC1, 0xC2, ...), then that particular mapping will be re-enabled by 0x05.

I don't know if this behavior also applies to the NP SNES cartridges. I don't have the hardware to test it.

Did you reverse engineer those commands by yourselves? Or did you find some documentation online somewhere? I would be happy if you remember the URL in that case.