### PR TITLE
Cleanups for SERIAL_MONITOR interface, and support "long press" with SERIAL_MONITOR

### DIFF
--- a/Cart_Reader/Cart_Reader.ino
+++ b/Cart_Reader/Cart_Reader.ino
@@ -267,11 +267,6 @@ boolean holdEventPast2 = false;      // whether or not the hold event happened a
 boolean longholdEventPast2 = false;  // whether or not the long hold event happened already
 #endif
 
-#ifdef ENABLE_SERIAL
-// For incoming serial data
-int incomingByte;
-#endif
-
 // Variables for the menu
 int choice = 0;
 // Temporary array that holds the menu option read out of progmem
@@ -2955,7 +2950,7 @@ byte questionBox_Serial(const __FlashStringHelper* question __attribute__((unuse
   }
 
   // Read the incoming byte:
-  incomingByte = Serial.read() - 48;
+  int incomingByte = Serial.read() - 48;
 
   // Page up (u)
   if (incomingByte == 69) {
@@ -3197,7 +3192,7 @@ void checkUpdater() {
 uint8_t checkButton() {
   while (Serial.available() == 0) {
   }
-  incomingByte = Serial.read() - 48;
+  int incomingByte = Serial.read() - 48;
 
   //Next
   if (incomingByte == 52) {
@@ -3223,7 +3218,7 @@ void wait_serial() {
   }
   while (Serial.available() == 0) {
   }
-  incomingByte = Serial.read() - 48;
+  int incomingByte = Serial.read() - 48;
   /* if ((incomingByte == 53) && (fileName[0] != '\0')) {
       // Open file on sd card
       sd.chdir(folder);

--- a/Cart_Reader/Cart_Reader.ino
+++ b/Cart_Reader/Cart_Reader.ino
@@ -3210,6 +3210,11 @@ uint8_t checkButton() {
     return 3;
   }
 
+  //Long Press (simulate)
+  else if ((incomingByte == 'l') || (incomingByte == 'L')) {
+    return 4;
+  }
+
   return 0;
 }
 

--- a/Cart_Reader/Cart_Reader.ino
+++ b/Cart_Reader/Cart_Reader.ino
@@ -2949,11 +2949,11 @@ byte questionBox_Serial(const __FlashStringHelper* question __attribute__((unuse
   while (Serial.available() == 0) {
   }
 
-  // Read the incoming byte:
-  int incomingByte = Serial.read() - 48;
+  // Read the incoming byte (can't be -1, as there must be data available)
+  char incomingByte = Serial.read();
 
   // Page up (u)
-  if (incomingByte == 69) {
+  if (incomingByte == 'u') {
     if (currPage > 1) {
       lastPage = currPage;
       currPage--;
@@ -2963,7 +2963,7 @@ byte questionBox_Serial(const __FlashStringHelper* question __attribute__((unuse
   }
 
   // Page down (d)
-  else if (incomingByte == 52) {
+  else if (incomingByte == 'd') {
     if (numPages > currPage) {
       lastPage = currPage;
       currPage++;
@@ -2971,14 +2971,14 @@ byte questionBox_Serial(const __FlashStringHelper* question __attribute__((unuse
   }
 
   // Execute choice
-  else if ((incomingByte >= 0) && (incomingByte < 7)) {
+  else if ((incomingByte >= '0') && (incomingByte < '7')) {
     numPages = 0;
   }
 
   // Print the received byte for validation e.g. in case of a different keyboard mapping
   //Serial.println(incomingByte);
   //Serial.println(FS(FSTRING_EMPTY));
-  return incomingByte;
+  return incomingByte - '0';
 }
 #endif
 
@@ -3192,20 +3192,21 @@ void checkUpdater() {
 uint8_t checkButton() {
   while (Serial.available() == 0) {
   }
-  int incomingByte = Serial.read() - 48;
+  // read() can't return -1 since there's data available.
+  char incomingByte = Serial.read();
 
   //Next
-  if (incomingByte == 52) {
+  if (incomingByte == 'd') {
     return 1;
   }
 
   //Previous
-  else if (incomingByte == 69) {
+  else if (incomingByte == 'u') {
     return 2;
   }
 
   //Selection
-  else if ((incomingByte == 240) || (incomingByte == -16) || (incomingByte == 0)) {
+  else if ((incomingByte == ' ') || (incomingByte == '0')) {
     return 3;
   }
 
@@ -3218,37 +3219,8 @@ void wait_serial() {
   }
   while (Serial.available() == 0) {
   }
-  int incomingByte = Serial.read() - 48;
-  /* if ((incomingByte == 53) && (fileName[0] != '\0')) {
-      // Open file on sd card
-      sd.chdir(folder);
-      if (myFile.open(fileName, O_READ)) {
-        // Get rom size from file
-        fileSize = myFile.fileSize();
-
-        // Send filesize
-        char tempStr[16];
-        sprintf(tempStr, "%d", fileSize);
-        Serial.write(tempStr);
-
-        // Wait for ok
-        while (Serial.available() == 0) {
-        }
-
-        // Send file
-        for (unsigned long currByte = 0; currByte < fileSize; currByte++) {
-          // Blink led
-          if (currByte % 1024 == 0)
-            blinkLED();
-          Serial.write(myFile.read());
-        }
-        // Close the file:
-        myFile.close();
-      }
-      else {
-        print_FatalError(open_file_STR);
-      }
-    }*/
+  // Result is ignored, so don't even bother putting it in a variable
+  Serial.read();
 }
 #endif
 


### PR DESCRIPTION
 - Removed a global variable that's only used by SERIAL_MONITOR that was better used as a local temporary variable (`incomingByte`). The local variables are also better typed to be either `byte` or `char` (I chose `char`s due to the next point).
 - Simplified `Serial.read()` cases to extract the character read as a char and not the subtraction of the character with 48. This reduced code size slightly.
 - The actual change that made me make this PR: I tried running the SNES clock calibration using SERIAL_MONITOR, but it wasn't able to trigger saving to the SD card because the `checkButton` implementation for SERIAL_MONITOR did not return `4`, or long press. I've implemented to return that value if the user sends `'l'` or `'L'`.
 -  Got rid of a large comment block in one of the SERIAL_MONITOR functions that seemed to have been copied from somewhere else, and did not seem relevant to the `wait` function.