### PR TITLE
Fix NES PRG address for mapper 24/26/78

### DIFF
--- a/Cart_Reader/NES.ino
+++ b/Cart_Reader/NES.ino
@@ -2095,7 +2095,7 @@ void readPRG(bool readrom) {
         banks = int_pow(2, prgsize);
         for (size_t i = 0; i < banks; i++) {  // 128K
           write_prg_byte(0x8000, i);
-          dumpBankPRG(0x2000, 0x4000, base);  // 16K Banks ($8000-$BFFF)
+          dumpBankPRG(0x0, 0x4000, base);  // 16K Banks ($8000-$BFFF)
         }
         break;
 


### PR DESCRIPTION
This is minor issue fix on NES PRG dump in mapper 24, 26 and 78.

For switchable PRG rom bank, it's required to read $8000-$BFFF (16kb). But it has read $A000-$BFFF, since the offset address is wrong. Thus, dumped PRG file is as half size as expected.

I've confirmed the code works in the following titles:
- Akumajou Densetsu (mapper 24)
- Esper Dream 2 - Aratanaru Tatakai (mapper 26)
- Mouryou Senki Madara (mapper 26)
- Uchuusen Cosmo Carrier (mapper 78)