### PR TITLE
Fix Famicom XEVIOUS dumping

### DIFF
--- a/Cart_Reader/NES.ino
+++ b/Cart_Reader/NES.ino
@@ -830,6 +830,7 @@ static void set_romsel(unsigned int address) {
 static unsigned char read_prg_byte(unsigned int address) {
   MODE_READ;
   PRG_READ;
+  ROMSEL_HI;
   set_address(address);
   PHI2_HI;
   set_romsel(address);


### PR DESCRIPTION
Some PRG ROM chips need a high to low transition on /CE to latch a new address. (Like the mask rom used by XEVIOUS.)
Currently the implementation of`read_prg_byte` will set /ROMSEL by A15 state but since we are dumping PRG ROM from
$8000 - $FFFF so A15 keeps high during dumping process.

On real hardware /ROMSEL also controlled by PHI2 signal so after every bus cycle, /ROMSEL will always be high, which makes ROM chip working properly.