### PR TITLE
Added SNES/SFC database entry for Cotton 100% (Columbus Circle Release)

### DIFF
--- a/sd/snes.txt
+++ b/sd/snes.txt
@@ -4921,6 +4921,9 @@ Madou Monogatari - Hanamaru Daiyouchienji (Japan).sfc
 Maerchen Adventure Cotton 100% (Japan).sfc
 5FB7A31D,CD3C,81AC7F8A,16,064
 
+Maerchen Adventure Cotton 100% (Japan) (Columbus Circle Release).sfc
+F4C10A72,1BF0,5C37BB91,16,064
+
 Magic Boy (Europe).sfc
 7718C867,05A7,103AC871,04,016
 


### PR DESCRIPTION
Added the database entry for SNES/SFC for Cotton 100% JPN (Columbus Circle Release).

This cart is an official aftermarket re-release of the original cart (https://www.amazon.co.jp/dp/B0C6SL86QG).

There are minor differences in the ROM dump for the credits to reflect the updated 2023 copyright.  While the read header checksum remains the same for the initial database lookup, the calculated checksum differs.  This means that the internal checksum check is expected to fail without a hack in the [`checkAltConf()` function in SNES.io](https://github.com/sanni/cartreader/blob/master/Cart_Reader/SNES.ino#L1057-L1150). However, the card dumps correctly and the final checksum results in the correct filename resolution from the database.

Log snippet:
```
SCR HW5 V14.5

[+] Super Nintendo/SFCSuper Nintendo/SFC

[+] SNES/SFC cartridgeSNES/SFC cartridge


Searching database...
Checksum: CD3C
Header CRC32: 5C37BB915C37BB91
Header CRC32: 81AC7F8A81AC7F8A
Found

Name: COTTON 100%
Revision: 0
Type: LoROM FastROM
ICs: ROM ONLY
ROM Size: 2 MB (64 banks)
Save Size: 0 KB
Checksum: CD3C

[+] Read ROMRead ROM


Saving to SNES/ROM/COTTON 100%/1062/...
[*******************]
Checksum... 1BF0 != CD3C
Invalid Checksum
CRC32... F4C10A72 -> Maerchen Adventure Cotton 100% (Japan) (Columbus Circle Release).sfc

```