### PR TITLE
Adds support for M29F080 flash to PCE

### DIFF
--- a/Cart_Reader/PCE.ino
+++ b/Cart_Reader/PCE.ino
@@ -903,6 +903,8 @@ void flash_PCE() {
       break;
     case 0xC2D5:
       // MX29F080 = 8Mbit
+    case 0x20F1:
+      // M29F080 = 8Mbit
       flashSize = 1048576UL;
       break;
   }


### PR DESCRIPTION
Got some of these 1MB flash chips to burn bigger games like Bonk 3 and Parodius, just need to recognize the device ID and all seems to work.