### PR TITLE
Identify SRAM chip when flashing Genesis CFI.

### DIFF
--- a/Cart_Reader/MD.ino
+++ b/Cart_Reader/MD.ino
@@ -3216,7 +3216,28 @@ void identifyFlashCFI_MD() {
   }
 }
 
+bool identifySramCFI_MD(byte currChip) {
+  dataIn_MD();
+  word firstWord = readFlashCFI_MD(currChip, 0x0);
+  dataOut_MD();
+  writeFlashCFI_MD(currChip, 0x0, firstWord + 0x0101);
+  dataIn_MD();
+  word readBack = readFlashCFI_MD(currChip, 0x0);
+  dataOut_MD();
+  writeFlashCFI_MD(currChip, 0x0, firstWord);
+  dataIn_MD();
+  // If we were able to change the value, this is a SRAM Chip and not Flash.
+  return firstWord != readBack;
+}
+
 void identifyFlashCFIChip_MD(byte currChip) {
+  if (currChip == 1 && identifySramCFI_MD(currChip)) {
+     print_Msg(F("Chip"));
+     print_Msg(currChip);
+     println_Msg(F(" SRAM"));
+     display_Update();
+     return;
+  }
   startCFIMode_MD(currChip);
   dataIn_MD();
   char cfiQRYx16[13];


### PR DESCRIPTION
In a board with 1 flash chip and SRAM, the SRAM is always enabled so attempting to detect it as CFI will fail.

This commit adds some simple code that attempts to modify address 0x0 of the chip to detect if the chip is ROM or SRAM. If the value changes upon writing to it, it will assume it's SRAM and ignore it when flashing.