### PR TITLE
fix build if ENABLE_MD is not defined

### DIFF
--- a/Cart_Reader/MD.ino
+++ b/Cart_Reader/MD.ino
@@ -3038,8 +3038,6 @@ void force_cartSize_MD() {
   delay(1000);
 }
 
-#endif
-
 // CFI Support
 #ifdef ENABLE_FLASH
 void eraseFlashCFI_MD() {
@@ -3324,6 +3322,8 @@ word readFlashCFI_MD(byte currChip, unsigned long myAddress) {
 }
 
 #endif // ENABLE_FLASH
+
+#endif // ENABLE_MD
 
 //******************************************
 // End of File


### PR DESCRIPTION
The code in master gets compilation errors when trying to build without ENABLE_MD defined.

```
Arduino: 1.8.19 (Windows 10), Board: "Arduino Mega or Mega 2560, ATmega2560 (Mega 2560)"
D:\Develop\cartreader_V15.0_Portable\Arduino IDE\portable\sketchbook\Cart_Reader\MD.ino: In function 'void eraseFlashCFI_MD()':
MD:3046:38: error: 'totalChipsCFI' was not declared in this scope
 3046 |   for (byte currChip = 0; currChip < totalChipsCFI; currChip++) {
      |                                      ^~~~~~~~~~~~~
D:\Develop\cartreader_V15.0_Portable\Arduino IDE\portable\sketchbook\Cart_Reader\MD.ino: In function 'void eraseFlashCFIChip_MD(byte)':
MD:3059:3: error: 'dataOut_MD' was not declared in this scope; did you mean 'dataOut16'?
 3059 |   dataOut_MD();
      |   ^~~~~~~~~~
      |   dataOut16
MD:3063:3: error: 'dataIn_MD' was not declared in this scope; did you mean 'dataIn8'?
 3063 |   dataIn_MD();
      |   ^~~~~~~~~
      |   dataIn8
D:\Develop\cartreader_V15.0_Portable\Arduino IDE\portable\sketchbook\Cart_Reader\MD.ino: In function 'void resetFlashCFI_MD()':
MD:3073:38: error: 'totalChipsCFI' was not declared in this scope
 3073 |   for (byte currChip = 0; currChip < totalChipsCFI; currChip++) {
      |                                      ^~~~~~~~~~~~~
D:\Develop\cartreader_V15.0_Portable\Arduino IDE\portable\sketchbook\Cart_Reader\MD.ino: In function 'void resetFlashCFIChip_MD(byte)':
MD:3079:3: error: 'dataOut_MD' was not declared in this scope; did you mean 'dataOut16'?
 3079 |   dataOut_MD();
      |   ^~~~~~~~~~
      |   dataOut16
D:\Develop\cartreader_V15.0_Portable\Arduino IDE\portable\sketchbook\Cart_Reader\MD.ino: In function 'void writeCFI_MD()':
MD:3088:20: error: 'totalFlashSizeCFI' was not declared in this scope
 3088 |     if (fileSize > totalFlashSizeCFI) {
      |                    ^~~~~~~~~~~~~~~~~
In file included from sketch\Cart_Reader.ino.cpp:1:
MD:3096:55: error: 'flashSizeCFI' was not declared in this scope; did you mean 'flashSize'?
 3096 |       unsigned long toFlash = min(fileSize - flashed, flashSizeCFI[currChip]);
      |                                                       ^~~~~~~~~~~~
D:\Develop\cartreader_V15.0_Portable\Arduino IDE\hardware\arduino\avr\cores\arduino/Arduino.h:92:24: note: in definition of macro 'min'
   92 | #define min(a,b) ((a)<(b)?(a):(b))
      |                        ^
D:\Develop\cartreader_V15.0_Portable\Arduino IDE\portable\sketchbook\Cart_Reader\MD.ino: In function 'void writeCFIChip_MD(byte, long unsigned int, long unsigned int)':
MD:3133:7: error: 'dataOut_MD' was not declared in this scope; did you mean 'dataOut16'?
 3133 |       dataOut_MD();
      |       ^~~~~~~~~~
      |       dataOut16
MD:3139:7: error: 'dataIn_MD' was not declared in this scope; did you mean 'dataIn8'?
 3139 |       dataIn_MD();
      |       ^~~~~~~~~
      |       dataIn8
D:\Develop\cartreader_V15.0_Portable\Arduino IDE\portable\sketchbook\Cart_Reader\MD.ino: In function 'void verifyFlashCFI_MD()':
MD:3159:20: error: 'totalFlashSizeCFI' was not declared in this scope
 3159 |     if (fileSize > totalFlashSizeCFI) {
      |                    ^~~~~~~~~~~~~~~~~
MD:3166:57: error: 'flashSizeCFI' was not declared in this scope; did you mean 'flashSize'?
 3166 |       unsigned long toVerify = min(fileSize - verified, flashSizeCFI[currChip]);
      |                                                         ^~~~~~~~~~~~
D:\Develop\cartreader_V15.0_Portable\Arduino IDE\hardware\arduino\avr\cores\arduino/Arduino.h:92:24: note: in definition of macro 'min'
   92 | #define min(a,b) ((a)<(b)?(a):(b))
      |                        ^
D:\Develop\cartreader_V15.0_Portable\Arduino IDE\portable\sketchbook\Cart_Reader\MD.ino: In function 'void verifyFlashCFIChip_MD(byte, long unsigned int)':
MD:3187:3: error: 'dataIn_MD' was not declared in this scope; did you mean 'dataIn8'?
 3187 |   dataIn_MD();
      |   ^~~~~~~~~
      |   dataIn8
D:\Develop\cartreader_V15.0_Portable\Arduino IDE\portable\sketchbook\Cart_Reader\MD.ino: In function 'void identifyFlashCFI_MD()':
MD:3211:3: error: 'totalChipsCFI' was not declared in this scope
 3211 |   totalChipsCFI = 0;
      |   ^~~~~~~~~~~~~
MD:3212:3: error: 'totalFlashSizeCFI' was not declared in this scope
 3212 |   totalFlashSizeCFI = 0;
      |   ^~~~~~~~~~~~~~~~~
MD:3215:26: error: 'flashSizeCFI' was not declared in this scope; did you mean 'flashSize'?
 3215 |     totalFlashSizeCFI += flashSizeCFI[currChip];
      |                          ^~~~~~~~~~~~
      |                          flashSize
D:\Develop\cartreader_V15.0_Portable\Arduino IDE\portable\sketchbook\Cart_Reader\MD.ino: In function 'bool identifySramCFI_MD(byte)':
MD:3220:3: error: 'dataIn_MD' was not declared in this scope; did you mean 'dataIn8'?
 3220 |   dataIn_MD();
      |   ^~~~~~~~~
      |   dataIn8
MD:3222:3: error: 'dataOut_MD' was not declared in this scope; did you mean 'dataOut16'?
 3222 |   dataOut_MD();
      |   ^~~~~~~~~~
      |   dataOut16
D:\Develop\cartreader_V15.0_Portable\Arduino IDE\portable\sketchbook\Cart_Reader\MD.ino: In function 'void identifyFlashCFIChip_MD(byte)':
MD:3242:3: error: 'dataIn_MD' was not declared in this scope; did you mean 'dataIn8'?
 3242 |   dataIn_MD();
      |   ^~~~~~~~~
      |   dataIn8
MD:3255:3: error: 'chipIdLowCFI' was not declared in this scope; did you mean 'chipIdLow'?
 3255 |   chipIdLowCFI[currChip] = chipIdLow;
      |   ^~~~~~~~~~~~
      |   chipIdLow
MD:3256:3: error: 'chipIdHighCFI' was not declared in this scope; did you mean 'chipIdHigh'?
 3256 |   chipIdHighCFI[currChip] = chipIdHigh;
      |   ^~~~~~~~~~~~~
      |   chipIdHigh
MD:3268:5: error: 'totalChipsCFI' was not declared in this scope
 3268 |     totalChipsCFI++;
      |     ^~~~~~~~~~~~~
MD:3269:5: error: 'flashSizeCFI' was not declared in this scope; did you mean 'flashSize'?
 3269 |     flashSizeCFI[currChip] = size;
      |     ^~~~~~~~~~~~
      |     flashSize
D:\Develop\cartreader_V15.0_Portable\Arduino IDE\portable\sketchbook\Cart_Reader\MD.ino: In function 'void startCFIMode_MD(byte)':
MD:3300:3: error: 'dataOut_MD' was not declared in this scope; did you mean 'dataOut16'?
 3300 |   dataOut_MD();
      |   ^~~~~~~~~~
      |   dataOut16
D:\Develop\cartreader_V15.0_Portable\Arduino IDE\portable\sketchbook\Cart_Reader\MD.ino: In function 'void writeFlashCFI_MD(byte, long unsigned int, word)':
MD:3311:12: error: 'writeFlash_MD' was not declared in this scope; did you mean 'writeFlash_SFM'?
 3311 |     return writeFlash_MD(myAddress | (1L << 20), myData);
      |            ^~~~~~~~~~~~~
      |            writeFlash_SFM
MD:3313:12: error: 'writeFlash_MD' was not declared in this scope; did you mean 'writeFlash_SFM'?
 3313 |     return writeFlash_MD(myAddress, myData);
      |            ^~~~~~~~~~~~~
      |            writeFlash_SFM
D:\Develop\cartreader_V15.0_Portable\Arduino IDE\portable\sketchbook\Cart_Reader\MD.ino: In function 'word readFlashCFI_MD(byte, long unsigned int)':
MD:3320:12: error: 'readFlash_MD' was not declared in this scope; did you mean 'readFlash_SFM'?
 3320 |     return readFlash_MD(myAddress | (1L << 20));
      |            ^~~~~~~~~~~~
      |            readFlash_SFM
MD:3322:12: error: 'readFlash_MD' was not declared in this scope; did you mean 'readFlash_SFM'?
 3322 |     return readFlash_MD(myAddress);
      |            ^~~~~~~~~~~~
      |            readFlash_SFM
exit status 1
'totalChipsCFI' was not declared in this scope
```
