### PR TITLE
Fix SD read in CRC calculation

### DIFF
--- a/Cart_Reader/Cart_Reader.ino
+++ b/Cart_Reader/Cart_Reader.ino
@@ -419,10 +419,10 @@ uint32_t calculateCRC(const byte* buffer, size_t length) {
 }
 
 uint32_t calculateCRC(FsFile& infile) {
-  uint32_t byte_count;
+  int32_t byte_count;
   uint32_t crc = 0xFFFFFFFF;
 
-  while ((byte_count = infile.read(sdBuffer, sizeof(sdBuffer))) != 0) {
+  while ((byte_count = infile.read(sdBuffer, sizeof(sdBuffer))) > 0) {
     crc = updateCRC(sdBuffer, byte_count, crc);
   }
   return ~crc;


### PR DESCRIPTION
In very rare cases, the CRC calculation becomes incorrect even though the ROM file itself is generated correctly, and the CRC value differs on each run.

The suspected cause is that read() may return -1 at end-of-file, but the return value is stored in a uint32_t. As a result, the loop condition evaluates as true and the CRC is updated unintentionally.

With this change, the issue no longer occurs in my environment. I also verified that normal CRC calculations are unaffected.

This issue is extremely difficult to reproduce, but I would appreciate it if you could review it when you have time.